### PR TITLE
Sign w/ Sigstore and upload Sigstore verification materials

### DIFF
--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -144,7 +144,7 @@ def list_files(release):
     for rfile in os.listdir(path.join(ftp_root, reldir)):
         if not path.isfile(path.join(ftp_root, reldir, rfile)):
             continue
-        if rfile.endswith('.asc'):
+        if rfile.endswith(('.asc', '.sig', '.crt')):
             continue
         for prefix in ('python', 'Python'):
             if rfile.startswith(prefix):

--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -126,8 +126,16 @@ def build_file_dict(release, rfile, rel_pk, file_desc, os_pk, add_desc):
             )
         ),
     )
+    # Upload GPG signature
     if os.path.exists(ftp_root + "%s/%s.asc" % (base_version(release), rfile)):
         d["gpg_signature_file"] = sigfile_for(base_version(release), rfile)
+    # Upload Sigstore signature
+    if os.path.exists(ftp_root + "%s/%s.sig" % (base_version(release), rfile)):
+        d["sigstore_signature_file"] = download_root + '%s/%s.sig' % (release, rfile)
+    # Upload Sigstore certificate
+    if os.path.exists(ftp_root + "%s/%s.crt" % (base_version(release), rfile)):
+        d["sigstore_cert_file"] = download_root + '%s/%s.crt' % (release, rfile)
+
     return d
 
 def list_files(release):

--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -31,10 +31,32 @@ from os import path
 import re
 import sys
 import time
+import subprocess
 
 import requests
 
-from release import run_cmd
+# Copied from release.py
+def error(*msgs):
+    print('**ERROR**', file=sys.stderr)
+    for msg in msgs:
+        print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+# Copied from release.py
+def run_cmd(cmd, silent=False, shell=True, **kwargs):
+    if shell:
+        cmd = ' '.join(cmd)
+    if not silent:
+        print('Executing %s' % cmd)
+    try:
+        if silent:
+            subprocess.check_call(cmd, shell=shell, stdout=subprocess.PIPE, **kwargs)
+        else:
+            subprocess.check_call(cmd, shell=shell, **kwargs)
+    except subprocess.CalledProcessError:
+        error('%s failed' % cmd)
+
 
 try:
     auth_info = os.environ['AUTH_INFO']

--- a/release.py
+++ b/release.py
@@ -262,7 +262,7 @@ def tarball(source):
     print('  %s  %8s  %s' % (
         checksum_xz.hexdigest(), int(os.path.getsize(xz)), xz))
 
-    print('Signing tarballs')
+    print('Signing tarballs with GPG')
     uid = os.environ.get("GPG_KEY_FOR_RELEASE")
     if not uid:
         print('List of available private keys:')
@@ -270,6 +270,9 @@ def tarball(source):
         uid = input('Please enter key ID to use for signing: ')
     os.system('gpg -bas -u ' + uid + ' ' + tgz)
     os.system('gpg -bas -u ' + uid + ' ' + xz)
+
+    print('Signging tarballs with Sigstore')
+    run_cmd(['python3', '-m', 'sigstore', 'sign', '--oidc-disable-ambient-providers', tgz, xz])
 
 
 def export(tag, silent=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ alive_progress
 python-gnupg
 aiohttp
 blurb
+sigstore


### PR DESCRIPTION
Pairs with https://github.com/python/pythondotorg/pull/2113.

I didn't see where non-source release artifacts were getting signed, looks like it's happening outside this process, but if we want to include that here too, point me in the right direction and I'll add it.

(cc @python/python-release-managers)