### PR TITLE
Fix issues with Sigstore signing

### DIFF
--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -155,10 +155,10 @@ def build_file_dict(release, rfile, rel_pk, file_desc, os_pk, add_desc):
         d["gpg_signature_file"] = sigfile_for(base_version(release), rfile)
     # Upload Sigstore signature
     if os.path.exists(ftp_root + "%s/%s.sig" % (base_version(release), rfile)):
-        d["sigstore_signature_file"] = download_root + '%s/%s.sig' % (release, rfile)
+        d["sigstore_signature_file"] = download_root + '%s/%s.sig' % (base_version(release), rfile)
     # Upload Sigstore certificate
     if os.path.exists(ftp_root + "%s/%s.crt" % (base_version(release), rfile)):
-        d["sigstore_cert_file"] = download_root + '%s/%s.crt' % (release, rfile)
+        d["sigstore_cert_file"] = download_root + '%s/%s.crt' % (base_version(release), rfile)
 
     return d
 

--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -244,6 +244,10 @@ def sign_release_files_with_sigstore(release, release_files):
     print('Signging release files with Sigstore')
     run_cmd(['python3', '-m', 'sigstore', 'sign', '--oidc-disable-ambient-providers'] + filenames)
 
+    # Update permissions on Sigstore verification materials to match other downloads
+    run_cmd(["find", ftp_root, "-type", "f", "\(", "-iname", "\*.sig", "-o", "-iname", "\*.crt", "\)", "exec", "chmod", "644", "{}", "\\;"])
+
+
 def main():
     rel = sys.argv[1]
     print('Querying python.org for release', rel)

--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -254,8 +254,7 @@ def main():
     rel_pk = query_object('release', name='Python+' + rel)
     print('Found Release object: id =', rel_pk)
     release_files = list(list_files(rel))
-    # TODO: Uncomment when this is synced with the rest of the release scripts
-    # sign_release_files_with_sigstore(rel, release_files)
+    sign_release_files_with_sigstore(rel, release_files)
     n = 0
     file_dicts = {}
     for rfile, file_desc, os_pk, add_desc in release_files:

--- a/release.py
+++ b/release.py
@@ -271,9 +271,8 @@ def tarball(source):
     os.system('gpg -bas -u ' + uid + ' ' + tgz)
     os.system('gpg -bas -u ' + uid + ' ' + xz)
 
-    # TODO: Uncomment when this is synced with the rest of the release scripts
-    # print('Signging tarballs with Sigstore')
-    # run_cmd(['python3', '-m', 'sigstore', 'sign', '--oidc-disable-ambient-providers', tgz, xz])
+    print('Signging tarballs with Sigstore')
+    run_cmd(['python3', '-m', 'sigstore', 'sign', '--oidc-disable-ambient-providers', tgz, xz])
 
 
 def export(tag, silent=False):

--- a/release.py
+++ b/release.py
@@ -271,7 +271,7 @@ def tarball(source):
     os.system('gpg -bas -u ' + uid + ' ' + tgz)
     os.system('gpg -bas -u ' + uid + ' ' + xz)
 
-    print('Signging tarballs with Sigstore')
+    print('Signing tarballs with Sigstore')
     run_cmd(['python3', '-m', 'sigstore', 'sign', '--oidc-disable-ambient-providers', tgz, xz])
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ alive_progress
 python-gnupg
 aiohttp
 blurb
-sigstore
+sigstore>0.6.6

--- a/run_release.py
+++ b/run_release.py
@@ -724,7 +724,7 @@ def run_add_to_python_dot_org(db: DbfilenameShelf) -> None:
     client.connect(DOWNLOADS_SERVER, port=22, username=db["ssh_user"])
 
     # Ensure the file is there
-    source = pathlib.Path(__file__).parent / "add-to-pydotorg.py" 
+    source = pathlib.Path(__file__).parent / "add-to-pydotorg.py"
     destination = pathlib.Path(f"/home/psf-users/{db['ssh_user']}/add-to-pydotorg.py")
     ftp_client = MySFTPClient.from_transport(client.get_transport())
     ftp_client.put(str(source), str(destination))

--- a/run_release.py
+++ b/run_release.py
@@ -732,8 +732,10 @@ def run_add_to_python_dot_org(db: DbfilenameShelf) -> None:
 
     auth_info = db["auth_info"]
     assert auth_info is not None
+    # Do the interactive flow to get an identity for Sigstore
+    identity_token = subprocess.check_output(["python", "-m", "sigstore", "get-identity-token"]).strip().decode()
     stdin, stdout, stderr = client.exec_command(
-        f"AUTH_INFO={auth_info} python add-to-pydotorg.py {db['release']}"
+        f"AUTH_INFO={auth_info} IDENTITY_TOKEN={identity_token} python add-to-pydotorg.py {db['release']}"
     )
     stderr_text = stderr.read().decode()
     if stderr_text:


### PR DESCRIPTION
Fixes #21.

Note that this requires `sigstore` to be installed on both the local machine (to generate an identity token) and the remote machine (to actually do the signing). This also requires the newly released `sigstore>0.6.6`, I've updated the `requirements.txt` file to match.

I _think_ this will correctly pass `IDENTITY_TOKEN` through all the right layers to be present when Sigstore is invoked on the remote machine, but I wasn't able to test this.