### PR TITLE
Issues-related whatsnew template tweaks.

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -83,11 +83,11 @@ WHATS_NEW_TEMPLATE = """
    * Credit the author of a patch or bugfix.   Just the name is
    sufficient; the e-mail address isn't necessary.
 
-   * It's helpful to add the bug/patch number as a comment:
+   * It's helpful to add the issue number as a comment:
 
    XXX Describe the transmogrify() function added to the socket
    module.
-   (Contributed by P.Y. Developer in :issue:`12345`.)
+   (Contributed by P.Y. Developer in :gh:`12345`.)
 
    This saves the maintainer the effort of going through the Mercurial log
    when researching a change.


### PR DESCRIPTION
This tweaks the template to mention issues and `:gh:` as done in:
* https://github.com/python/cpython/pull/98124