### PR TITLE
Update whatsnew template

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -83,13 +83,13 @@ WHATS_NEW_TEMPLATE = """
    * Credit the author of a patch or bugfix.   Just the name is
    sufficient; the e-mail address isn't necessary.
 
-   * It's helpful to add the bug/patch number as a comment:
+   * It's helpful to add the issue number as a comment:
 
    XXX Describe the transmogrify() function added to the socket
    module.
-   (Contributed by P.Y. Developer in :issue:`12345`.)
+   (Contributed by P.Y. Developer in :gh:`12345`.)
 
-   This saves the maintainer the effort of going through the Mercurial log
+   This saves the maintainer the effort of going through the VCS log
    when researching a change.
 
 This article explains the new features in Python {version}, compared to {prev_version}.


### PR DESCRIPTION
Use `:gh:` instead of `:issue:`, clarify that it should be the GH issue number, and remove Mercurial reference.

See https://github.com/python/cpython/pull/98124 for the first two changes in 3.12 whatsnew.