### PR TITLE
Enable use of Azure Key Vault to store code signing certificate for Windows releases

### DIFF
--- a/windows-release/README.md
+++ b/windows-release/README.md
@@ -1,16 +1,39 @@
 # Windows Releases
 
 This build script is used for official releases of CPython on Windows.
-It is somewhat more complex than `Tools/msi/buildrelease.bat` because it uses additional parallelism,
-and limits the use of our VM that contains the code signing certificate,
-but fundamentally achieves the same output.
+It is somewhat more complex than `Tools/msi/buildrelease.bat` because it uses additional parallelism
+and uses our official code signing certificate.
 
 This script is designed to be run on Azure Pipelines.
 Information about the syntax can be found at https://docs.microsoft.com/azure/devops/pipelines/
 
 The current deployment is at https://dev.azure.com/Python/cpython/_build?definitionId=21
-Chances are you don't have permission to do anything other than view builds.
-If you do have permission, you also need to launch the VM with the build tools, including code signing certificate.
-This VM is maintained by the Windows build manager and should be strictly controlled.
+Chances are you don't have permission to do anything other than view builds. Access is controlled by the release team.
+
+If you do have permission, you can launch a release build by selecting **Run pipeline**,
+specify the desired **Git remote** and **Git tag**, enable **Publish release**,
+toggle any version specific options, and click **Run**.
+
+The version specific options are required due to changes in our build that require modifications
+to the publish pipeline. For example, whether to publish ARM64 binaries.
+
+When signing is enabled (any value besides "Unsigned"), authorised approvers will be notified and
+will need to approve each stage that requires the signing certificate (typically three).
+This helps prevent "surprise" builds from using the official certificate.
+
+The code signing certificate is stored in Azure Key Vault, and is authenticated using the
+variables in a Variable group called CPythonSign. The variable group is what triggers approvals.
+The group is at https://dev.azure.com/Python/cpython/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=1&path=CPythonSign
+
+To upload a new code signing certificate (which will be provided by the PSF),
+or to change to a new Azure Keyvault instance,
+see the documentation at https://github.com/vcsjones/AzureSignTool/blob/main/WALKTHROUGH.md.
+
+GPG signature generation uses a GPG key stored in the Secure Files library.
+This can be found at https://dev.azure.com/Python/cpython/_library?itemType=SecureFiles
+Regardless of who triggers the build, the signatures will be attributed to whoever's key is used.
+The passphrase for the key is a secure build variable,
+and can be modified by editing the build definition and selecting **Variables**.
+(TODO: Move the passphrase and reference to the file into the CPythonSign variable group.)
 
 (Further documentation to be added as we find out what ought to be documented.)

--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -80,7 +80,6 @@ parameters:
   default: '0'
 
 variables:
-  __RealSigningCertificate: 'Python Software Foundation'
   ${{ if ne(parameters.GitRemote, '(Other)') }}:
     GitRemote: ${{ parameters.GitRemote }}
   ${{ else }}:
@@ -90,6 +89,10 @@ variables:
   ${{ if ne(parameters.SigningCertificate, 'Unsigned') }}:
     SigningCertificate: ${{ parameters.SigningCertificate }}
   SigningDescription: ${{ parameters.SigningDescription }}
+  ${{ if eq(parameters.SigningCertificate, 'Python Software Foundation') }}:
+    IsRealSigned: true
+  ${{ else }}:
+    IsRealSigned: false
   DoCHM: ${{ parameters.DoCHM }}
   DoLayout: ${{ parameters.DoLayout }}
   DoMSIX: ${{ parameters.DoMSIX }}
@@ -119,6 +122,8 @@ stages:
     dependsOn: Build
     jobs:
     - template: stage-sign.yml
+      parameters:
+        SigningCertificate: ${{ parameters.SigningCertificate }}
 
   - stage: Layout
     displayName: Generate layouts
@@ -134,6 +139,9 @@ stages:
     dependsOn: Layout
     jobs:
     - template: stage-pack-nuget.yml
+      parameters:
+        ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
+          SigningCertificate: ${{ parameters.SigningCertificate }}
 
   - stage: Test
     dependsOn: Pack
@@ -155,6 +163,9 @@ stages:
       dependsOn: Layout_MSIX
       jobs:
       - template: stage-pack-msix.yml
+        parameters:
+          ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
+            SigningCertificate: ${{ parameters.SigningCertificate }}
 
   - ${{ if eq(parameters.DoMSI, 'true') }}:
     - stage: Build_MSI
@@ -164,6 +175,8 @@ stages:
       - template: stage-msi.yml
         parameters:
           ARM64TclTk: ${{ parameters.ARM64TclTk }}
+          ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
+            SigningCertificate: ${{ parameters.SigningCertificate }}
 
     - stage: Test_MSI
       displayName: Test MSI installer

--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -26,9 +26,9 @@ parameters:
 - name: SigningCertificate
   displayName: "Code signing certificate"
   type: string
-  default: 'Python Software Foundation'
+  default: 'PythonSoftwareFoundation'
   values:
-  - 'Python Software Foundation'
+  - 'PythonSoftwareFoundation'
   - 'TestSign'
   - 'Unsigned'
 - name: SigningDescription
@@ -90,7 +90,7 @@ variables:
   ${{ if ne(parameters.SigningCertificate, 'Unsigned') }}:
     SigningCertificate: ${{ parameters.SigningCertificate }}
   SigningDescription: ${{ parameters.SigningDescription }}
-  ${{ if eq(parameters.SigningCertificate, 'Python Software Foundation') }}:
+  ${{ if eq(parameters.SigningCertificate, 'PythonSoftwareFoundation') }}:
     IsRealSigned: true
   ${{ else }}:
     IsRealSigned: false

--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -124,7 +124,8 @@ stages:
     jobs:
     - template: stage-sign.yml
       parameters:
-        SigningCertificate: ${{ parameters.SigningCertificate }}
+        ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
+          SigningCertificate: ${{ parameters.SigningCertificate }}
 
   - stage: Layout
     displayName: Generate layouts

--- a/windows-release/build-steps.yml
+++ b/windows-release/build-steps.yml
@@ -56,7 +56,7 @@ steps:
 
 - task: PublishPipelineArtifact@0
   displayName: 'Publish binaries'
-  condition: and(succeeded(), not(and(eq(variables['Configuration'], 'Release'), variables['SigningCertificate'])))
+  condition: and(succeeded(), or(ne(variables['Configuration'], 'Release'), not(variables['SigningCertificate'])))
   inputs:
     targetPath: '$(Build.BinariesDirectory)\bin\$(Arch)'
     artifactName: bin_$(Name)

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -1,5 +1,6 @@
 parameters:
   ARM64TclTk: true
+  SigningCertificate: ''
 
 steps:
   - template: ./checkout.yml
@@ -80,10 +81,10 @@ steps:
         artifactName: tcltk_lib_arm64
         targetPath: $(Build.BinariesDirectory)\tcltk_lib_arm64
 
-  - powershell: |
-      copy $(Build.BinariesDirectory)\amd64\Activate.ps1 Lib\venv\scripts\common\Activate.ps1 -Force
-    displayName: 'Copy signed files into sources'
-    condition: and(succeeded(), variables['SigningCertificate'])
+  - ${{ if parameters.SigningCertificate }}:
+    - powershell: |
+        copy $(Build.BinariesDirectory)\amd64\Activate.ps1 Lib\venv\scripts\common\Activate.ps1 -Force
+      displayName: 'Copy signed files into sources'
 
   - script: |
       call Tools\msi\get_externals.bat
@@ -98,50 +99,75 @@ steps:
       %PYTHON% -m blurb merge -f Misc\NEWS
     displayName: 'Merge NEWS file'
 
+  - powershell: |
+      ("/p:Py_OutDir=" + $env:BUILD_BINARIESDIRECTORY) | Out-File msbuild.rsp -Encoding UTF8
+      "/p:BuildForRelease=true" | Out-File msbuild.rsp -Append -Encoding UTF8
+      Write-Host "##vso[task.setvariable variable=ResponseFile]$(gi msbuild.rsp)"
+      gc msbuild.rsp
+    displayName: 'Generate response file'
+
+  - ${{ if parameters.SigningCertificate }}:
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: 'custom'
+        custom: 'tool'
+        arguments: 'install --global azuresigntool'
+      displayName: Install AzureSignTool
+
+    - powershell: |
+        $signcmd = 'AzureSignTool sign -kvu "$(KeyVaultUri)" ' + `
+                   '-kvi "$(KeyVaultApplication)" -kvt "$(KeyVaultDirectory)" -kvs "$(KeyVaultSecret)" ' + `
+                   '-tr http://timestamp.digicert.com/ -td sha256 ' + `
+                   '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256 '
+        "/p:_SignCommand=$signcmd" | Out-File $env:ResponseFile -Append -Encoding UTF8
+      displayName: 'Inject signing command into response file'
+      env:
+        ResponseFile: $(ResponseFile)
+
   - script: |
-      %MSBUILD% Tools\msi\launcher\launcher.wixproj
+      %MSBUILD% Tools\msi\launcher\launcher.wixproj "@$(ResponseFile)"
     displayName: 'Build launcher installer'
     env:
       Platform: x86
-      Py_OutDir: $(Build.BinariesDirectory)
 
   - script: |
-      %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true
+      %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true "@$(ResponseFile)"
     displayName: 'Build win32 installer'
     env:
       Platform: x86
-      Py_OutDir: $(Build.BinariesDirectory)
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_win32
-      BuildForRelease: true
 
   - script: |
-      %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true
+      %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true "@$(ResponseFile)"
     displayName: 'Build amd64 installer'
     env:
       Platform: x64
-      Py_OutDir: $(Build.BinariesDirectory)
       PYTHON: $(Build.BinariesDirectory)\amd64\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\amd64\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_amd64
-      BuildForRelease: true
 
   - script: |
-      %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true
+      %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true "@$(ResponseFile)"
     displayName: 'Build arm64 installer'
     condition: and(succeeded(), eq(variables['PublishARM64'], 'true'))
     env:
       Platform: ARM64
-      Py_OutDir: $(Build.BinariesDirectory)
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
-      BuildForRelease: true
       ${{ if eq(parameters.ARM64TclTk, true) }}:
         TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_arm64
+
+  - powershell: |
+      del $env:ResponseFile -ErrorAction Continue
+    displayName: 'Remove response file (always runs)'
+    condition: ne(variables['ResponseFile'], '')
+    env:
+      ResponseFile: $(ResponseFile)
 
   - task: CopyFiles@2
     displayName: 'Assemble artifact: msi (win32)'

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -120,7 +120,7 @@ steps:
                    '-tr http://timestamp.digicert.com/ -td sha256 ' + `
                    '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256'
         $signcmd = $signcmd -replace '"', '\"'
-        "/p:_SignCommand=$signcmd" | Out-File $env:ResponseFile -Append -Encoding UTF8
+        "/p:_SignCommand=""$signcmd""" | Out-File $env:ResponseFile -Append -Encoding UTF8
       displayName: 'Inject signing command into response file'
       env:
         ResponseFile: $(ResponseFile)

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -119,9 +119,7 @@ steps:
                    '-kvi "$(KeyVaultApplication)" -kvt "$(KeyVaultDirectory)" -kvs "$(KeyVaultSecret)" ' + `
                    '-tr http://timestamp.digicert.com/ -td sha256 ' + `
                    '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256 '
-        Write-Host "##vso[task.setvariable variable=SignCommandOverride,issecret=true]$signcmd"
-        # Deliberately not substituting here - let MSBuild do the substitution later
-        '/p:_SignCommand="$(SignCommandOverride)"' | Out-File $env:ResponseFile -Append -Encoding UTF8
+        "'/p:_SignCommand=$signcmd'" | Out-File $env:ResponseFile -Append -Encoding UTF8
       displayName: 'Inject signing command into response file'
       env:
         ResponseFile: $(ResponseFile)

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -118,8 +118,8 @@ steps:
         $signcmd = 'AzureSignTool sign -kvu "$(KeyVaultUri)" ' + `
                    '-kvi "$(KeyVaultApplication)" -kvt "$(KeyVaultDirectory)" -kvs "$(KeyVaultSecret)" ' + `
                    '-tr http://timestamp.digicert.com/ -td sha256 ' + `
-                   '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256 '
-        "'/p:_SignCommand=$signcmd'" | Out-File $env:ResponseFile -Append -Encoding UTF8
+                   '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256'
+        "/p:_SignCommand='$signcmd'" | Out-File $env:ResponseFile -Append -Encoding UTF8
       displayName: 'Inject signing command into response file'
       env:
         ResponseFile: $(ResponseFile)
@@ -129,7 +129,6 @@ steps:
     displayName: 'Build launcher installer'
     env:
       Platform: x86
-      SignCommandOverride: $(SignCommandOverride)
 
   - script: |
       %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true "@$(ResponseFile)"
@@ -139,7 +138,6 @@ steps:
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
-      SignCommandOverride: $(SignCommandOverride)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_win32
 
   - script: |
@@ -150,7 +148,6 @@ steps:
       PYTHON: $(Build.BinariesDirectory)\amd64\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\amd64\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
-      SignCommandOverride: $(SignCommandOverride)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_amd64
 
   - script: |
@@ -161,7 +158,6 @@ steps:
       Platform: ARM64
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
-      SignCommandOverride: $(SignCommandOverride)
       PYTHONHOME: $(Build.SourcesDirectory)
       ${{ if eq(parameters.ARM64TclTk, true) }}:
         TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_arm64

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -119,8 +119,9 @@ steps:
                    '-kvi "$(KeyVaultApplication)" -kvt "$(KeyVaultDirectory)" -kvs "$(KeyVaultSecret)" ' + `
                    '-tr http://timestamp.digicert.com/ -td sha256 ' + `
                    '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256 '
-        $signcmd = $signcmd -replace '"', '\"'
-        "'/p:_SignCommand=$signcmd'" | Out-File $env:ResponseFile -Append -Encoding UTF8
+        Write-Host "##vso[task.setvariable variable=SignCommandOverride,issecret=true]$signcmd"
+        # Deliberately not substituting here - let MSBuild do the substitution later
+        '/p:_SignCommand="$(SignCommandOverride)"' | Out-File $env:ResponseFile -Append -Encoding UTF8
       displayName: 'Inject signing command into response file'
       env:
         ResponseFile: $(ResponseFile)
@@ -130,6 +131,7 @@ steps:
     displayName: 'Build launcher installer'
     env:
       Platform: x86
+      SignCommandOverride: $(SignCommandOverride)
 
   - script: |
       %MSBUILD% Tools\msi\bundle\releaselocal.wixproj /t:Rebuild /p:RebuildAll=true "@$(ResponseFile)"
@@ -139,6 +141,7 @@ steps:
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
+      SignCommandOverride: $(SignCommandOverride)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_win32
 
   - script: |
@@ -149,6 +152,7 @@ steps:
       PYTHON: $(Build.BinariesDirectory)\amd64\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\amd64\python.exe
       PYTHONHOME: $(Build.SourcesDirectory)
+      SignCommandOverride: $(SignCommandOverride)
       TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_amd64
 
   - script: |
@@ -159,6 +163,7 @@ steps:
       Platform: ARM64
       PYTHON: $(Build.BinariesDirectory)\win32\python.exe
       PythonForBuild: $(Build.BinariesDirectory)\win32\python.exe
+      SignCommandOverride: $(SignCommandOverride)
       PYTHONHOME: $(Build.SourcesDirectory)
       ${{ if eq(parameters.ARM64TclTk, true) }}:
         TclTkLibraryDir: $(Build.BinariesDirectory)\tcltk_lib_arm64

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -119,7 +119,8 @@ steps:
                    '-kvi "$(KeyVaultApplication)" -kvt "$(KeyVaultDirectory)" -kvs "$(KeyVaultSecret)" ' + `
                    '-tr http://timestamp.digicert.com/ -td sha256 ' + `
                    '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256'
-        "/p:_SignCommand='$signcmd'" | Out-File $env:ResponseFile -Append -Encoding UTF8
+        $signcmd = $signcmd -replace '"', '\"'
+        "/p:_SignCommand=$signcmd" | Out-File $env:ResponseFile -Append -Encoding UTF8
       displayName: 'Inject signing command into response file'
       env:
         ResponseFile: $(ResponseFile)

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -119,7 +119,7 @@ steps:
                    '-kvi "$(KeyVaultApplication)" -kvt "$(KeyVaultDirectory)" -kvs "$(KeyVaultSecret)" ' + `
                    '-tr http://timestamp.digicert.com/ -td sha256 ' + `
                    '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256 '
-        "/p:_SignCommand=$signcmd" | Out-File $env:ResponseFile -Append -Encoding UTF8
+        "/p:_SignCommand=""$signcmd""" | Out-File $env:ResponseFile -Append -Encoding UTF8
       displayName: 'Inject signing command into response file'
       env:
         ResponseFile: $(ResponseFile)

--- a/windows-release/msi-steps.yml
+++ b/windows-release/msi-steps.yml
@@ -119,7 +119,8 @@ steps:
                    '-kvi "$(KeyVaultApplication)" -kvt "$(KeyVaultDirectory)" -kvs "$(KeyVaultSecret)" ' + `
                    '-tr http://timestamp.digicert.com/ -td sha256 ' + `
                    '-kvc "${{ parameters.SigningCertificate }}" -d "$(SigningDescription)" -fd sha256 '
-        "/p:_SignCommand=""$signcmd""" | Out-File $env:ResponseFile -Append -Encoding UTF8
+        $signcmd = $signcmd -replace '"', '\"'
+        "'/p:_SignCommand=$signcmd'" | Out-File $env:ResponseFile -Append -Encoding UTF8
       displayName: 'Inject signing command into response file'
       env:
         ResponseFile: $(ResponseFile)

--- a/windows-release/sign-files.yml
+++ b/windows-release/sign-files.yml
@@ -1,0 +1,53 @@
+parameters:
+  Include: '*'
+  Exclude: ''
+  WorkingDir: '$(Build.BinariesDirectory)'
+  ExtractDir: ''
+  SigningCertificate: ''
+
+steps:
+- ${{ if parameters.SigningCertificate }}:
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: 'custom'
+      custom: 'tool'
+      arguments: 'install --global azuresigntool'
+    displayName: Install AzureSignTool
+
+  - powershell: |
+      if ("${{ parameters.Exclude }}") {
+        $files = (gi ${{ parameters.Include }} -Exclude ${{ parameters.Exclude }})
+      } else {
+        $files = (gi ${{ parameters.Include }})
+      }
+      AzureSignTool sign -kvu '$(KeyVaultUri)' `
+                    -kvi '$(KeyVaultApplication)' -kvt '$(KeyVaultDirectory)' -kvs '$(KeyVaultSecret)' `
+                    -tr http://timestamp.digicert.com/ -td sha256 `
+                    -kvc '${{ parameters.SigningCertificate }}' -d '$(SigningDescription)' -fd sha256 `
+                    $files
+    displayName: 'Sign binaries'
+    retryCountOnTaskFailure: 3
+    workingDirectory: ${{ parameters.WorkingDir }}
+
+- ${{ if parameters.ExtractDir }}:
+  - powershell: |
+      if ("${{ parameters.Exclude }}") {
+        $files = (gi ${{ parameters.Include }} -Exclude ${{ parameters.Exclude }})
+      } else {
+        $files = (gi ${{ parameters.Include }})
+      }
+      $c = $files | %{ (Get-AuthenticodeSignature $_).SignerCertificate } | ?{ $_ -ne $null } | select -First 1
+      if (-not $c) {
+        Write-Host "Failed to find certificate for ${{ parameters.SigningCertificate }}"
+        exit
+      }
+
+      $d = mkdir "${{ parameters.ExtractDir }}" -Force
+      $cf = "$d\cert.cer"
+      [IO.File]::WriteAllBytes($cf, $c.RawData)
+      $csha = (Get-FileHash $cf -Algorithm SHA256).Hash.ToLower()
+
+      $info = @{ Subject=$c.Subject; SHA256=$csha; }
+      $info | ConvertTo-JSON -Compress | Out-File -Encoding utf8 "$d\certinfo.json"
+    displayName: "Extract certificate info"
+    workingDirectory: ${{ parameters.WorkingDir }}

--- a/windows-release/sign-nuget-files.yml
+++ b/windows-release/sign-nuget-files.yml
@@ -1,0 +1,29 @@
+parameters:
+  Include: '*.nupkg'
+  Exclude: ''
+  WorkingDir: '$(Build.BinariesDirectory)'
+  SigningCertificate: ''
+
+steps:
+- ${{ if parameters.SigningCertificate }}:
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: 'custom'
+      custom: 'tool'
+      arguments: 'install --global NuGetKeyVaultSignTool'
+    displayName: Install NuGetKeyVaultSignTool
+
+  - powershell: |
+      if ("${{ parameters.Exclude }}") {
+        $files = (gi ${{ parameters.Include }} -Exclude ${{ parameters.Exclude }})
+      } else {
+        $files = (gi ${{ parameters.Include }})
+      }
+      NuGetKeyVaultSignTool sign -kvu '$(KeyVaultUri)' `
+                    -kvi '$(KeyVaultApplication)' -kvt '$(KeyVaultDirectory)' -kvs '$(KeyVaultSecret)' `
+                    -tr http://timestamp.digicert.com/ -td sha256 `
+                    -kvc '${{ parameters.SigningCertificate }}' -d '$(SigningDescription)' -fd sha256 `
+                    $files
+    displayName: 'Sign binaries'
+    retryCountOnTaskFailure: 3
+    workingDirectory: ${{ parameters.WorkingDir }}

--- a/windows-release/sign-nuget-files.yml
+++ b/windows-release/sign-nuget-files.yml
@@ -19,6 +19,8 @@ steps:
       } else {
         $files = (gi ${{ parameters.Include }})
       }
+      gcm NuGetKeyVaultSignTool
+      NuGetKeyVaultSignTool -h
       NuGetKeyVaultSignTool sign -kvu '$(KeyVaultUri)' `
                     -kvi '$(KeyVaultApplication)' -kvt '$(KeyVaultDirectory)' -kvs '$(KeyVaultSecret)' `
                     -tr http://timestamp.digicert.com/ -td sha256 `

--- a/windows-release/sign-nuget-files.yml
+++ b/windows-release/sign-nuget-files.yml
@@ -19,12 +19,10 @@ steps:
       } else {
         $files = (gi ${{ parameters.Include }})
       }
-      gcm NuGetKeyVaultSignTool
-      NuGetKeyVaultSignTool -h
       NuGetKeyVaultSignTool sign -kvu '$(KeyVaultUri)' `
                     -kvi '$(KeyVaultApplication)' -kvt '$(KeyVaultDirectory)' -kvs '$(KeyVaultSecret)' `
                     -tr http://timestamp.digicert.com/ -td sha256 `
-                    -kvc '${{ parameters.SigningCertificate }}' -d '$(SigningDescription)' -fd sha256 `
+                    -kvc '${{ parameters.SigningCertificate }}' -fd sha256 `
                     $files
     displayName: 'Sign binaries'
     retryCountOnTaskFailure: 3

--- a/windows-release/stage-build.yml
+++ b/windows-release/stage-build.yml
@@ -116,7 +116,7 @@ jobs:
   timeoutInMinutes: 300
 
   pool:
-    name: 'Windows Release'
+    vmImage: windows-2022
 
   workspace:
     clean: all

--- a/windows-release/stage-msi.yml
+++ b/windows-release/stage-msi.yml
@@ -1,43 +1,50 @@
 parameters:
   ARM64TclTk: true
+  SigningCertificate: ''
 
 jobs:
-- job: Make_MSI
-  displayName: Make MSI
-  condition: and(succeeded(), not(variables['SigningCertificate']))
+- ${{ if parameters.SigningCertificate }}:
+  - job: Make_Signed_MSI
+    displayName: Make signed MSI
+  
+    pool:
+      vmImage: windows-2022
+  
+    variables:
+    - group: CPythonSign
+    - name: ReleaseUri
+      value: http://www.python.org/{arch}
+    - name: DownloadUrl
+      value: https://www.python.org/ftp/python/{version}/{arch}{releasename}/{msi}
+    - name: Py_OutDir
+      value: $(Build.BinariesDirectory)
+  
+    workspace:
+      clean: all
+  
+    steps:
+    - template: msi-steps.yml
+      parameters:
+        ARM64TclTk: ${{ parameters.ARM64TclTk }}
+        SigningCertificate: ${{ parameters.SigningCertificate }}
 
-  pool:
-    vmImage: windows-2022
 
-  variables:
-    ReleaseUri: http://www.python.org/{arch}
-    DownloadUrl: https://www.python.org/ftp/python/{version}/{arch}{releasename}/{msi}
-    Py_OutDir: $(Build.BinariesDirectory)
-
-  workspace:
-    clean: all
-
-  steps:
-  - template: msi-steps.yml
-    parameters:
-      ARM64TclTk: ${{ parameters.ARM64TclTk }}
-
-- job: Make_Signed_MSI
-  displayName: Make signed MSI
-  condition: and(succeeded(), variables['SigningCertificate'])
-
-  pool:
-    name: 'Windows Release'
-
-  variables:
-    ReleaseUri: http://www.python.org/{arch}
-    DownloadUrl: https://www.python.org/ftp/python/{version}/{arch}{releasename}/{msi}
-    Py_OutDir: $(Build.BinariesDirectory)
-
-  workspace:
-    clean: all
-
-  steps:
-  - template: msi-steps.yml
-    parameters:
-      ARM64TclTk: ${{ parameters.ARM64TclTk }}
+- ${{ else }}:
+  - job: Make_MSI
+    displayName: Make MSI
+  
+    pool:
+      vmImage: windows-2022
+  
+    variables:
+      ReleaseUri: http://www.python.org/{arch}
+      DownloadUrl: https://www.python.org/ftp/python/{version}/{arch}{releasename}/{msi}
+      Py_OutDir: $(Build.BinariesDirectory)
+  
+    workspace:
+      clean: all
+  
+    steps:
+    - template: msi-steps.yml
+      parameters:
+        ARM64TclTk: ${{ parameters.ARM64TclTk }}

--- a/windows-release/stage-pack-msix.yml
+++ b/windows-release/stage-pack-msix.yml
@@ -1,3 +1,6 @@
+parameters:
+  SigningCertificate: ''
+
 jobs:
 - job: Pack_MSIX
   displayName: Pack MSIX bundles
@@ -73,7 +76,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: MSIX'
-    condition: and(succeeded(), and(eq(variables['ShouldSign'], 'true'), variables['SigningCertificate']))
+    condition: and(succeeded(), eq(variables['ShouldSign'], 'true'), variables['SigningCertificate'])
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\msix'
       ArtifactName: unsigned_msix
@@ -91,58 +94,47 @@ jobs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\msixupload'
       ArtifactName: msixupload
 
+- ${{ if parameters.SigningCertificate }}:
+  - job: Sign_MSIX
+    displayName: Sign side-loadable MSIX bundles
+    dependsOn:
+    - Pack_MSIX
 
-- job: Sign_MSIX
-  displayName: Sign side-loadable MSIX bundles
-  dependsOn:
-  - Pack_MSIX
-  condition: and(succeeded(), variables['SigningCertificate'])
+    pool:
+      vmImage: windows-2022
 
-  pool:
-    name: 'Windows Release'
+    workspace:
+      clean: all
 
-  workspace:
-    clean: all
+    variables:
+    - group: CPythonSign
 
-  steps:
-  - template: ./checkout.yml
-  - template: ./find-sdk.yml
+    steps:
+    - template: ./checkout.yml
 
-  - powershell: |
-      $d = (.\PCbuild\build.bat -V) | %{ if($_ -match '\s+(\w+):\s*(.+)\s*$') { @{$Matches[1] = $Matches[2];} }};
-      Write-Host "##vso[task.setvariable variable=SigningDescription]Python $($d.PythonVersion)"
-    displayName: 'Update signing description'
-    condition: and(succeeded(), not(variables['SigningDescription']))
+    - powershell: |
+        $d = (.\PCbuild\build.bat -V) | %{ if($_ -match '\s+(\w+):\s*(.+)\s*$') { @{$Matches[1] = $Matches[2];} }};
+        Write-Host "##vso[task.setvariable variable=SigningDescription]Python $($d.PythonVersion)"
+      displayName: 'Update signing description'
+      condition: and(succeeded(), not(variables['SigningDescription']))
 
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Artifact: unsigned_msix'
-    inputs:
-      artifactName: unsigned_msix
-      downloadPath: $(Build.BinariesDirectory)
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Artifact: unsigned_msix'
+      inputs:
+        artifactName: unsigned_msix
+        downloadPath: $(Build.BinariesDirectory)
 
-  # MSIX must be signed and timestamped simultaneously
-  #
-  # Getting "Error: SignerSign() failed." (-2147024885/0x8007000b)"?
-  # It may be that the certificate info collected in stage-sign.yml is wrong. Check that
-  # you do not have multiple matches for the certificate name you have specified.
-  - powershell: |
-      $failed = $true
-      foreach ($retry in 1..3) {
-          signtool sign /a /n "$(SigningCertificate)" /fd sha256 /tr http://timestamp.digicert.com/ /td sha256 /d "$(SigningDescription)" (gi *.msix)
-          if ($?) {
-              $failed = $false
-              break
-          }
-          sleep 1
-      }
-      if ($failed) {
-          throw "Failed to sign MSIX"
-      }
-    displayName: 'Sign MSIX'
-    workingDirectory: $(Build.BinariesDirectory)\unsigned_msix
+    # Getting "Error: SignerSign() failed." (-2147024885/0x8007000b)"?
+    # It may be that the certificate info collected in stage-sign.yml is wrong. Check that
+    # you do not have multiple matches for the certificate name you have specified.
+    - template: sign-files.yml
+      parameters:
+        Include: '*.msix'
+        WorkingDir: $(Build.BinariesDirectory)\unsigned_msix
+        SigningCertificate: ${{ parameters.SigningCertificate }}
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: MSIX'
-    inputs:
-      PathtoPublish: '$(Build.BinariesDirectory)\unsigned_msix'
-      ArtifactName: msix
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: MSIX'
+      inputs:
+        PathtoPublish: '$(Build.BinariesDirectory)\unsigned_msix'
+        ArtifactName: msix

--- a/windows-release/stage-pack-nuget.yml
+++ b/windows-release/stage-pack-nuget.yml
@@ -1,10 +1,13 @@
+parameters:
+  SigningCertificate: ''
+
 jobs:
 - job: Pack_Nuget
   displayName: Pack Nuget bundles
   condition: and(succeeded(), eq(variables['DoNuget'], 'true'))
 
   pool:
-    name: 'Windows Release'
+    vmImage: windows-2022
 
   workspace:
     clean: all
@@ -17,6 +20,10 @@ jobs:
         Name: win32
       arm64:
         Name: arm64
+
+  ${{ if parameters.SigningCertificate }}:
+    variables:
+    - group: CPythonSign
 
   steps:
   - checkout: none
@@ -51,13 +58,11 @@ jobs:
     condition: and(succeeded(), variables['OverrideNugetVersion'])
     displayName: 'Create nuget package'
 
-  - powershell: |
-      gci *.nupkg | %{
-        nuget sign "$_" -CertificateSubjectName "$(SigningCertificate)" -Timestamper http://timestamp.digicert.com/ -Overwrite
-      }
-    displayName: 'Sign nuget package'
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), variables['SigningCertificate'])
+  - template: sign-files.yml
+    parameters:
+      Include: '*.nupkg'
+      WorkingDir: $(Build.ArtifactStagingDirectory)
+      SigningCertificate: ${{ parameters.SigningCertificate }}
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: nuget'

--- a/windows-release/stage-pack-nuget.yml
+++ b/windows-release/stage-pack-nuget.yml
@@ -58,7 +58,7 @@ jobs:
     condition: and(succeeded(), variables['OverrideNugetVersion'])
     displayName: 'Create nuget package'
 
-  - template: sign-files.yml
+  - template: sign-nuget-files.yml
     parameters:
       Include: '*.nupkg'
       WorkingDir: $(Build.ArtifactStagingDirectory)

--- a/windows-release/stage-publish-nugetorg.yml
+++ b/windows-release/stage-publish-nugetorg.yml
@@ -42,7 +42,7 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: Push packages
-    condition: and(succeeded(), eq(variables['SigningCertificate'], variables['__RealSigningCertificate']))
+    condition: and(succeeded(), eq(variables['IsRealSigned'], 'true'))
     inputs:
       command: push
       packagesToPush: '$(Build.BinariesDirectory)\nuget\*.nupkg'

--- a/windows-release/stage-publish-pythonorg.yml
+++ b/windows-release/stage-publish-pythonorg.yml
@@ -7,8 +7,7 @@ jobs:
   condition: and(succeeded(), eq(variables['DoMSI'], 'true'), eq(variables['DoEmbed'], 'true'), ne(variables['SkipPythonOrgPublish'], 'true'))
 
   pool:
-    #vmImage: windows-2022
-    name: 'Windows Release'
+    vmImage: windows-2022
 
   workspace:
     clean: all
@@ -121,8 +120,8 @@ jobs:
       -skippurge
       -skiptest
       -skiphash
-    condition: and(succeeded(), eq(variables['SigningCertificate'], variables['__RealSigningCertificate']))
     workingDirectory: $(Build.BinariesDirectory)
+    condition: and(succeeded(), eq(variables['IsRealSigned'], 'true'))
     displayName: 'Upload files to python.org'
 
   - powershell: >
@@ -130,7 +129,7 @@ jobs:
       "$(Build.SourcesDirectory)\Tools\msi\purge.py"
       (gci msi\*\python-*.exe | %{ $_.Name -replace 'python-(.+?)(-|\.exe).+', '$1' } | select -First 1)
     workingDirectory: $(Build.BinariesDirectory)
-    condition: and(succeeded(), eq(variables['SigningCertificate'], variables['__RealSigningCertificate']))
+    condition: and(succeeded(), eq(variables['IsRealSigned'], 'true'))
     displayName: 'Purge CDN'
 
   - powershell: |
@@ -150,8 +149,8 @@ jobs:
         Write-Error "Failed to validate $failures installers"
         exit 1
       }
-    condition: and(succeeded(), eq(variables['SigningCertificate'], variables['__RealSigningCertificate']))
     workingDirectory: $(Build.BinariesDirectory)
+    condition: and(succeeded(), eq(variables['IsRealSigned'], 'true'))
     displayName: 'Test layouts'
 
   - powershell: |

--- a/windows-release/stage-publish-store.yml
+++ b/windows-release/stage-publish-store.yml
@@ -34,5 +34,6 @@ jobs:
         artifactName: msixupload
         downloadPath: $(Build.BinariesDirectory)
 
-  # TODO: eq(variables['SigningCertificate'], variables['__RealSigningCertificate'])
-  # If we are not real-signed, DO NOT PUBLISH
+  # TODO: do publish step
+  # If we are *not* real-signed, DO NOT PUBLISH
+  # condition: and(succeeded(), eq(variables['IsRealSigned'], 'true'))

--- a/windows-release/stage-sign.yml
+++ b/windows-release/stage-sign.yml
@@ -1,130 +1,86 @@
 parameters:
   Include: '*.exe, *.dll, *.pyd, *.cat, *.ps1'
   Exclude: 'vcruntime*, libffi*, libcrypto*, libssl*'
+  SigningCertificate: ''
 
 jobs:
-- job: Sign_Python
-  displayName: Sign Python binaries
-  condition: and(succeeded(), variables['SigningCertificate'])
+- ${{ if parameters.SigningCertificate }}:
+  - job: Sign_Files
+    displayName: Sign Python binaries
 
-  pool:
-    name: 'Windows Release'
+    pool:
+      vmImage: windows-2022
 
-  workspace:
-    clean: all
+    workspace:
+      clean: all
 
-  strategy:
-    matrix:
-      win32:
-        Name: win32
-      amd64:
-        Name: amd64
-      arm64:
-        Name: arm64
+    strategy:
+      matrix:
+        win32:
+          Name: win32
+        amd64:
+          Name: amd64
+        arm64:
+          Name: arm64
 
-  steps:
-  - template: ./checkout.yml
-  - template: ./find-sdk.yml
+    variables:
+    - group: CPythonSign
 
-  - powershell: |
-      $d = (.\PCbuild\build.bat -V) | %{ if($_ -match '\s+(\w+):\s*(.+)\s*$') { @{$Matches[1] = $Matches[2];} }};
-      Write-Host "##vso[task.setvariable variable=SigningDescription]Python $($d.PythonVersion)"
-    displayName: 'Update signing description'
-    condition: and(succeeded(), not(variables['SigningDescription']))
+    steps:
+    - template: ./checkout.yml
 
-  - powershell: |
-      Write-Host "##vso[build.addbuildtag]signed"
-    displayName: 'Add build tags'
+    - powershell: |
+        $d = (.\PCbuild\build.bat -V) | %{ if($_ -match '\s+(\w+):\s*(.+)\s*$') { @{$Matches[1] = $Matches[2];} }};
+        Write-Host "##vso[task.setvariable variable=SigningDescription]Python $($d.PythonVersion)"
+      displayName: 'Update signing description'
+      condition: and(succeeded(), not(variables['SigningDescription']))
 
-  - task: DownloadPipelineArtifact@1
-    displayName: 'Download artifact: unsigned_bin_$(Name)'
-    inputs:
-      artifactName: unsigned_bin_$(Name)
-      targetPath: $(Build.BinariesDirectory)\bin
+    - powershell: |
+        Write-Host "##vso[build.addbuildtag]signed"
+      displayName: 'Add build tags'
 
-  - powershell: |
-      copy "$(Build.SourcesDirectory)\Lib\venv\scripts\common\Activate.ps1" .
-    displayName: 'Copy files from source'
-    workingDirectory: $(Build.BinariesDirectory)\bin
+    - task: DownloadPipelineArtifact@1
+      displayName: 'Download artifact: unsigned_bin_$(Name)'
+      inputs:
+        artifactName: unsigned_bin_$(Name)
+        targetPath: $(Build.BinariesDirectory)\bin
 
-  - powershell: |
-      $files = (gi ${{ parameters.Include }} -Exclude ${{ parameters.Exclude }})
-      signtool sign /a /n "$(SigningCertificate)" /fd sha256 /d "$(SigningDescription)" $files
-    displayName: 'Sign binaries'
-    workingDirectory: $(Build.BinariesDirectory)\bin
+    - powershell: |
+        copy "$(Build.SourcesDirectory)\Lib\venv\scripts\common\Activate.ps1" .
+      displayName: 'Copy files from source'
+      workingDirectory: $(Build.BinariesDirectory)\bin
 
-  - powershell: |
-      $files = (gi ${{ parameters.Include }} -Exclude ${{ parameters.Exclude }})
-      $failed = $true
-      foreach ($retry in 1..10) {
-          signtool timestamp /tr http://timestamp.digicert.com/ /td sha256 $files
-          if ($?) {
-              $failed = $false
-              break
-          }
-          sleep 5
-      }
-      if ($failed) {
-          Write-Host "##vso[task.logissue type=error]Failed to timestamp files"
-      }
-    displayName: 'Timestamp binaries'
-    workingDirectory: $(Build.BinariesDirectory)\bin
-    continueOnError: true
+    - template: sign-files.yml
+      parameters:
+        Include: ${{ parameters.Include }}
+        Exclude: ${{ parameters.Exclude }}
+        WorkingDir: $(Build.BinariesDirectory)\bin
+        ExtractDir: $(Build.BinariesDirectory)\cert
+        SigningCertificate: ${{ parameters.SigningCertificate }}
 
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish artifact: bin_$(Name)'
-    inputs:
-      targetPath: '$(Build.BinariesDirectory)\bin'
-      artifactName: bin_$(Name)
+    - task: PublishPipelineArtifact@0
+      displayName: 'Publish artifact: bin_$(Name)'
+      inputs:
+        targetPath: '$(Build.BinariesDirectory)\bin'
+        artifactName: bin_$(Name)
+
+    - task: PublishPipelineArtifact@0
+      displayName: 'Publish artifact: cert'
+      inputs:
+        targetPath: '$(Build.BinariesDirectory)\cert'
+        artifactName: cert
 
 
-- job: Dump_CertInfo
-  displayName: Capture certificate info
-  condition: and(succeeded(), variables['SigningCertificate'])
+- ${{ else }}:
+  - job: Mark_Unsigned
+    displayName: Tag unsigned build
 
-  pool:
-    name: 'Windows Release'
+    pool:
+      vmImage: windows-2022
 
-  steps:
-  - checkout: none
+    steps:
+    - checkout: none
 
-  - powershell: |
-      $m = 'CN=$(SigningCertificate)'
-      $c = ((gci Cert:\CurrentUser\My), (gci Cert:\LocalMachine\My)) | %{ $_ } | `
-         ?{ $_.Subject -match $m -and $_.NotBefore -lt (Get-Date) -and $_.NotAfter -gt (Get-Date) } | `
-         select -First 1
-      if (-not $c) {
-          Write-Host "Failed to find certificate for $(SigningCertificate)"
-          exit
-      }
-      $d = mkdir "$(Build.BinariesDirectory)\tmp" -Force
-      $cf = "$d\cert.cer"
-      [IO.File]::WriteAllBytes($cf, $c.Export("Cer"))
-      $csha = (certutil -dump $cf | sls "Cert Hash\(sha256\): (.+)").Matches.Groups[1].Value
-
-      $info = @{ Subject=$c.Subject; SHA256=$csha; }
-
-      $d = mkdir "$(Build.BinariesDirectory)\cert" -Force
-      $info | ConvertTo-JSON -Compress | Out-File -Encoding utf8 "$d\certinfo.json"
-    displayName: "Extract certificate info"
-
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish artifact: cert'
-    inputs:
-      targetPath: '$(Build.BinariesDirectory)\cert'
-      artifactName: cert
-
-
-- job: Mark_Unsigned
-  displayName: Tag unsigned build
-  condition: and(succeeded(), not(variables['SigningCertificate']))
-
-  pool:
-    vmImage: windows-2022
-
-  steps:
-  - checkout: none
-
-  - powershell: |
-      Write-Host "##vso[build.addbuildtag]unsigned"
-    displayName: 'Add build tag'
+    - powershell: |
+        Write-Host "##vso[build.addbuildtag]unsigned"
+      displayName: 'Add build tag'


### PR DESCRIPTION
This updates the build process for Windows release builds to sign using Azure Key Vault (through AzureSignTool and NugetKeyVaultSignTool). This means we can rely entirely on Azure Pipelines hosted VMs instead of running our own, and anyone with permission to trigger a build can do it.