### PR TITLE
Ensure publish steps always come after anything that might intermittently fail

### DIFF
--- a/windows-release/stage-layout-msix.yml
+++ b/windows-release/stage-layout-msix.yml
@@ -74,12 +74,6 @@ jobs:
     env:
       TCL_LIBRARY: $(TclLibrary)
 
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Artifact: layout_appxstore_$(Name)'
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)\appx-store'
-      artifactName: layout_appxstore_$(Name)
-
   - powershell: |
       $info = (gc "$(Build.BinariesDirectory)\cert\certinfo.json" | ConvertFrom-JSON)
       Write-Host "Side-loadable APPX must be signed with '$($info.Subject)'"
@@ -94,6 +88,12 @@ jobs:
     displayName: 'Generate sideloading APPX layout'
     env:
       TCL_LIBRARY: $(TclLibrary)
+
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Artifact: layout_appxstore_$(Name)'
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)\appx-store'
+      artifactName: layout_appxstore_$(Name)
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: layout_appx_$(Name)'

--- a/windows-release/stage-layout-msix.yml
+++ b/windows-release/stage-layout-msix.yml
@@ -53,6 +53,13 @@ jobs:
       artifactName: tcltk_lib_$(Name)
       targetPath: $(Build.BinariesDirectory)\tcltk_lib
 
+  - task: DownloadPipelineArtifact@1
+    displayName: 'Download artifact: cert'
+    condition: and(succeeded(), variables['SigningCertificate'])
+    inputs:
+      artifactName: cert
+      targetPath: $(Build.BinariesDirectory)\cert
+
   - powershell: |
       copy "$(Build.BinariesDirectory)\bin\Activate.ps1" Lib\venv\scripts\common\Activate.ps1 -Force
     displayName: 'Copy signed files into sources'
@@ -72,13 +79,6 @@ jobs:
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)\appx-store'
       artifactName: layout_appxstore_$(Name)
-
-  - task: DownloadPipelineArtifact@1
-    displayName: 'Download artifact: cert'
-    condition: and(succeeded(), variables['SigningCertificate'])
-    inputs:
-      artifactName: cert
-      targetPath: $(Build.BinariesDirectory)\cert
 
   - powershell: |
       $info = (gc "$(Build.BinariesDirectory)\cert\certinfo.json" | ConvertFrom-JSON)

--- a/windows-release/stage-pack-msix.yml
+++ b/windows-release/stage-pack-msix.yml
@@ -67,6 +67,12 @@ jobs:
     displayName: 'Build appxsym'
     workingDirectory: $(Build.BinariesDirectory)\symbols\$(Name)
 
+  - powershell: |
+      7z a -tzip "$(Build.ArtifactStagingDirectory)\msixupload\$(Filename).msixupload" *
+    displayName: 'Build msixupload'
+    condition: and(succeeded(), eq(variables['Upload'], 'true'))
+    workingDirectory: $(Build.ArtifactStagingDirectory)\msix
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: MSIX'
     condition: and(succeeded(), or(ne(variables['ShouldSign'], 'true'), not(variables['SigningCertificate'])))
@@ -80,12 +86,6 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\msix'
       ArtifactName: unsigned_msix
-
-  - powershell: |
-      7z a -tzip "$(Build.ArtifactStagingDirectory)\msixupload\$(Filename).msixupload" *
-    displayName: 'Build msixupload'
-    condition: and(succeeded(), eq(variables['Upload'], 'true'))
-    workingDirectory: $(Build.ArtifactStagingDirectory)\msix
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: MSIXUpload'


### PR DESCRIPTION
After an artifact is published, the build step cannot be retried. For steps that may fail intermittently, we want to allow retrying, and so the publish step must come after anything that might require a retry.