### PR TITLE
Verify after signing that identity and provider are as documented

### DIFF
--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -79,7 +79,6 @@ google_oidc_provider = 'https://accounts.google.com'
 # Update this list when new release managers are added.
 release_to_sigstore_identity_and_oidc_issuer = {
     '3.7': ('nad@python.org', github_oidc_provider),
-    # TODO: 3.8 and 3.9 don't match documented identity of 'lukasz@python.org'
     '3.8': ('lukasz@langa.pl', github_oidc_provider),
     '3.9': ('lukasz@langa.pl', github_oidc_provider),
     '3.10': ('pablogsal@python.org', google_oidc_provider),


### PR DESCRIPTION
Ensures that Sigstore-signed files for releases match the documented identity and providers on the https://python.org/downloads/sigstore page once the values are documented. This PR will solve future issues with signing like the ones that were noted in https://github.com/sigstore/sigstore-python/issues/600.

The only outstanding issue from https://github.com/sigstore/sigstore-python/issues/600 is 3.8 and 3.9 not matching the documented identity. I figure consistency in the short-term with what's happened historically is likely better than something different happening without our knowledge. We will figure out long-term what to do to fix that issue.