### PR TITLE
gh-34: remove "Release" and "Date" from whatsnew

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -50,8 +50,7 @@ WHATS_NEW_TEMPLATE = """
   What's New In Python {version}
 ****************************
 
-:Release: |release|
-:Date: |today|
+:Editor: TBD
 
 .. Rules for maintenance:
 


### PR DESCRIPTION
The "Release" and "Date" fields are no longer needed in the What's New pages, so I removed them from the template.

Fixes https://github.com/python/release-tools/issues/34
https://github.com/python/cpython/issues/106967