### PR TITLE
Fix warning about "blurb release" not executed

### DIFF
--- a/release.py
+++ b/release.py
@@ -464,7 +464,7 @@ def make_tag(tag):
     if bad_files or not good_files:
         print('It doesn\'t look like you ran "blurb release" yet.')
         if bad_files:
-            print('There are still ReST files in NEWS.d/next/...')
+            print('There are still reST files in NEWS.d/next/...')
         if not good_files:
             print(f'There is no Misc/NEWS.d/{tag}.rst file.')
         if input('Are you sure you want to tag? (y/n) > ') not in ("y", "yes"):

--- a/release.py
+++ b/release.py
@@ -462,7 +462,11 @@ def make_tag(tag):
     bad_files = list(glob.glob("Misc/NEWS.d/next/*/0*.rst"))
     bad_files.extend(glob.glob("Misc/NEWS.d/next/*/2*.rst"))
     if bad_files or not good_files:
-        print('It doesn\'t look like you didn\'t run "blurb release" yet.')
+        print('It doesn\'t look like you ran "blurb release" yet.')
+        if bad_files:
+            print('There are still ReST files in NEWS.d/next/...')
+        if not good_files:
+            print(f'There is no Misc/NEWS.d/{tag}.rst file.')
         if input('Are you sure you want to tag? (y/n) > ') not in ("y", "yes"):
             print("Aborting.")
             return False


### PR DESCRIPTION
There was a double negative and it wasn't clear why release.py thought "blurb release" wasn't executed.