### PR TITLE
Check commit SHA after checking out repository

### DIFF
--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -19,6 +19,10 @@ parameters:
   displayName: "Git tag"
   type: string
   default: main
+- name: SourceCommit
+  displayName: "Git commit (empty to disable commit SHA check)"
+  type: string
+  default: ''
 - name: DoPublish
   displayName: "Publish release"
   type: boolean
@@ -90,6 +94,7 @@ variables:
   ${{ else }}:
     GitRemote: ${{ parameters.GitRemote_Other }}
   SourceTag: ${{ parameters.SourceTag }}
+  SourceCommit: ${{ parameters.SourceCommit }}
   ${{ if ne(parameters.SigningCertificate, 'Unsigned') }}:
     SigningCertificate: ${{ parameters.SigningCertificate }}
   SigningDescription: ${{ parameters.SigningDescription }}

--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -20,9 +20,9 @@ parameters:
   type: string
   default: main
 - name: SourceCommit
-  displayName: "Git commit (empty to disable commit SHA check)"
+  displayName: "Git commit ('empty' to disable commit SHA check)"
   type: string
-  default: ''
+  default: 'empty'
 - name: DoPublish
   displayName: "Publish release"
   type: boolean
@@ -94,7 +94,10 @@ variables:
   ${{ else }}:
     GitRemote: ${{ parameters.GitRemote_Other }}
   SourceTag: ${{ parameters.SourceTag }}
-  SourceCommit: ${{ parameters.SourceCommit }}
+  ${{ if ne(parameters.SourceCommit, 'empty') }}:
+    SourceCommit: ${{ parameters.SourceCommit }}
+  ${{ else }}:
+    SourceCommit: ''
   ${{ if ne(parameters.SigningCertificate, 'Unsigned') }}:
     SigningCertificate: ${{ parameters.SigningCertificate }}
   SigningDescription: ${{ parameters.SigningDescription }}

--- a/windows-release/checkout.yml
+++ b/windows-release/checkout.yml
@@ -23,7 +23,7 @@ steps:
 - powershell: |
     $checkout_commit = (git rev-parse HEAD)
     if ($checkout_commit -ne '$(SourceCommit)') {
-        throw "Expected git commit '$(SourceCommit)' didn't match tagged commit '$(checkout_commit)'"
+        throw "Expected git commit '$(SourceCommit)' didn't match tagged commit '$checkout_commit'"
     }
   displayName: "Verify CPython commit matches tag"
   condition: and(succeeded(), variables['SourceCommit'])

--- a/windows-release/checkout.yml
+++ b/windows-release/checkout.yml
@@ -19,3 +19,11 @@ steps:
 - script: git clone --progress -v --depth ${{ parameters.depth }} --branch $(Build.SourceBranchName) --single-branch $(Build.Repository.Uri) .
   displayName: 'git clone'
   condition: and(succeeded(), and(not(variables['GitRemote']), not(variables['SourceTag'])))
+
+- powershell: |
+    $checkout_commit = (git rev-parse HEAD)
+    if ($checkout_commit -ne $GitCommit) {
+        throw "Expected git commit '$(GitCommit)' didn't match tagged commit '$(checkout_commit)'"
+    }
+  displayName: "Verify CPython commit matches tag"
+  condition: and(succeeded(), and(variables['GitCommit']))

--- a/windows-release/checkout.yml
+++ b/windows-release/checkout.yml
@@ -22,8 +22,8 @@ steps:
 
 - powershell: |
     $checkout_commit = (git rev-parse HEAD)
-    if ($checkout_commit -ne $GitCommit) {
-        throw "Expected git commit '$(GitCommit)' didn't match tagged commit '$(checkout_commit)'"
+    if ($checkout_commit -ne SourceCommit) {
+        throw "Expected git commit '$(SourceCommit)' didn't match tagged commit '$(checkout_commit)'"
     }
   displayName: "Verify CPython commit matches tag"
-  condition: and(succeeded(), and(variables['GitCommit']))
+  condition: and(succeeded(), variables['SourceCommit'])

--- a/windows-release/checkout.yml
+++ b/windows-release/checkout.yml
@@ -22,7 +22,7 @@ steps:
 
 - powershell: |
     $checkout_commit = (git rev-parse HEAD)
-    if ($checkout_commit -ne SourceCommit) {
+    if ($checkout_commit -ne '$(SourceCommit)') {
         throw "Expected git commit '$(SourceCommit)' didn't match tagged commit '$(checkout_commit)'"
     }
   displayName: "Verify CPython commit matches tag"


### PR DESCRIPTION
This adds an optional parameter and step to the "checkout" process which verifies that a given git tag resolves to a known commit SHA. This makes it far more difficult for someone with access to the release managers' fork of CPython on GitHub to spoof the inputs to the Windows installer builds (for example, changing the tag to a separate commit, and then changing it back after the build has started).

This requires specifying the git commit that's expected, so that value should be shared by the release manager through a separate channel to ensure the right value is used.

After this PR is accepted, I can propose an update of PEP 101 which provides this additional instruction for creating release builds.

My PowerShell is not up to par, I haven't ran Windows in around 8 years so please check that it's correct :)