### PR TITLE
Now pulls redistributable VC files from cpython-bin-deps

### DIFF
--- a/windows-release/acquire-vcruntime.yml
+++ b/windows-release/acquire-vcruntime.yml
@@ -1,0 +1,10 @@
+parameters:
+  Remote: https://github.com/python/cpython-bin-deps
+  Ref: vcruntime
+
+steps:
+- powershell: |
+    git clone --progress -v --depth 1 --branch ${{ parameters.Ref }} --single-branch ${{ parameters.Remote }} vcruntime
+    $files = (dir "vcruntime\$(arch)\*.dll").FullName -join ";"
+    "##vso[task.setvariable variable=VCRuntimeDLL]$files"
+  displayName: 'Import VC redist'

--- a/windows-release/build-steps-pgo.yml
+++ b/windows-release/build-steps-pgo.yml
@@ -7,6 +7,8 @@ steps:
 - template: ./checkout.yml
 
 - ${{ if or(eq(parameters.PGInstrument, 'true'), eq(parameters.PGUpdate, 'true')) }}:
+  - template: ./acquire-vcruntime.yml
+
   - powershell: |
       $d = (.\PCbuild\build.bat -V) | %{ if($_ -match '\s+(\w+):\s*(.+)\s*$') { @{$Matches[1] = $Matches[2];} }};
       Write-Host "##vso[task.setvariable variable=VersionText]$($d.PythonVersion)"

--- a/windows-release/build-steps.yml
+++ b/windows-release/build-steps.yml
@@ -3,6 +3,7 @@ parameters:
 
 steps:
 - template: ./checkout.yml
+- template: ./acquire-vcruntime.yml
 
 - powershell: |
     $d = (.\PCbuild\build.bat -V) | %{ if($_ -match '\s+(\w+):\s*(.+)\s*$') { @{$Matches[1] = $Matches[2];} }};


### PR DESCRIPTION
This ensures we will not downgrade DLL versions between releases, which leads to issues such as https://github.com/python/cpython/issues/110437