### PR TITLE
Remove redundant blank lines

### DIFF
--- a/release.py
+++ b/release.py
@@ -95,8 +95,6 @@ def chdir_to_repo_root():
     return root
 
 
-
-
 def get_output(args):
     return subprocess.check_output(args)
 


### PR DESCRIPTION
# Motivation
- There are too many blank lines between the function `get_output` and `chdir_to_repo_root` in `release.py` .

https://github.com/python/release-tools/blob/f9361ffd039b026107afb33aed4f6a3228d066a3/release.py#L94-L101


# Modification
- `release.py`  Remove redundant blank lines