### PR TITLE
Use 'regen-configure' Makefile target

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -412,17 +412,8 @@ def prepare_pydoc_topics(db: DbfilenameShelf) -> None:
 
 def run_autoconf(db: DbfilenameShelf) -> None:
     subprocess.check_call(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--pull=always",
-            f"-v{db['git_repo']}:/src",
-            "quay.io/tiran/cpython_autoconf:cp311",
-        ],
-        cwd=db["git_repo"],
+        ["make", "regen-configure"], cwd=db["git_repo"],
     )
-    subprocess.check_call(["docker", "rmi", "quay.io/tiran/cpython_autoconf", "-f"])
     subprocess.check_call(
         ["git", "commit", "-a", "--amend", "--no-edit"], cwd=db["git_repo"]
     )


### PR DESCRIPTION
Follow-up from https://github.com/python/cpython/issues/112160
Closes https://github.com/python/release-tools/issues/70

This uses `make regen-configure` instead of pulling in the Docker container. In the latest CPython branch we no longer use the autoconf container and in past branches the container is pinned to a hash which is preferable over a tag.
