### PR TITLE
Add potential SBOMs to python.org

### DIFF
--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -188,6 +188,9 @@ def build_file_dict(release, rfile, rel_pk, file_desc, os_pk,
     # Upload Sigstore bundle
     if os.path.exists(ftp_root + "%s/%s.sigstore" % (base_version(release), rfile)):
         d["sigstore_bundle_file"] = download_root + '%s/%s.sigstore' % (base_version(release), rfile)
+    # Upload SPDX SBOM file
+    if os.path.exists(ftp_root + "%s/%s.spdx.json" % (base_version(release), rfile)):
+        d["sbom_spdx2_file"] = download_root + '%s/%s.spdx.json' % (base_version(release), rfile)
 
     return d
 
@@ -197,7 +200,7 @@ def list_files(release):
     for rfile in os.listdir(path.join(ftp_root, reldir)):
         if not path.isfile(path.join(ftp_root, reldir, rfile)):
             continue
-        if rfile.endswith(('.asc', '.sig', '.crt', '.sigstore')):
+        if rfile.endswith(('.asc', '.sig', '.crt', '.sigstore', '.spdx.json')):
             continue
         for prefix in ('python', 'Python'):
             if rfile.startswith(prefix):


### PR DESCRIPTION
Part of https://github.com/python/cpython/issues/112302

Currently this code has no effect, however once SBOMs begin to be generated in https://github.com/python/release-tools/pull/82 there will be additional files so we need to do something with them to avoid failing releases on "unexpected file"

This PR is a follow-up from https://github.com/python/pythondotorg/pull/2359, so python.org now supports the field `sbom_spdx2_file`.