### PR TITLE
Add Dependabot to keep GitHub Actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v5.0.0
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: 3.x
       - run: |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# release-tools
+
+[![.github/workflows/test.yml](https://github.com/python/release-tools/actions/workflows/test.yml/badge.svg)](https://github.com/python/release-tools/actions/workflows/test.yml)
+
+Scripts for making (C)Python releases.


### PR DESCRIPTION
Follow on from https://github.com/python/release-tools/pull/93.

Monthly, and grouped, to keep it less spammy.

Also add README with build badge.
