### PR TITLE
Sort arrays in SBOM JSON data for reproducibility

### DIFF
--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -49,7 +49,12 @@ def test_normalization():
     # Normalization doesn't have to make too much sense,
     # only needs to be reproducible.
     data = {
-        "a": [1, 2, 3, {"b": [4, "c", [7, True, "2", {}]]}]
+        "a": [1, 2, 3, {"b": [4, "c", [7, True, "2", {}]]}],
+        # This line tests that inner structures are sorted first.
+        "b": [[1, 2, "b"], [2, 1, "a"]]
     }
     sbom.normalize_sbom_data(data)
-    assert data == {'a': [1, 2, 3, {'b': ['c', 4, ['2', 7, True, {}]]}]}
+    assert data == {
+        "a": [1, 2, 3, {"b": ["c", 4, ["2", 7, True, {}]]}],
+        "b": [["a", 1, 2], ["b", 1, 2]]
+    }

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -42,3 +42,14 @@ def test_calculate_package_verification_code(package_sha1s, package_verification
     assert input_sbom["packages"][0]["packageVerificationCode"] == {
         "packageVerificationCodeValue": package_verification_code
     }
+
+
+def test_normalization():
+    # Test that arbitrary JSON data can be normalized.
+    # Normalization doesn't have to make too much sense,
+    # only needs to be reproducible.
+    data = {
+        "a": [1, 2, 3, {"b": [4, "c", [7, True, "2", {}]]}]
+    }
+    sbom.normalize_sbom_data(data)
+    assert data == {'a': [1, 2, 3, {'b': ['c', 4, ['2', 7, True, {}]]}]}


### PR DESCRIPTION
This makes arrays in the SBOM JSON consistent regardless of how the internal workings of the script or filesystem/tarballs are structured. Tested manually by applying to the existing 3.12.2 SBOM and attempting to generate anew with the 3.12.2 tarball and confirmed that then only differences were the tool version (commit SHA) and creation date:

```diff
4c4
<     "created": "2024-02-08T22:18:26Z",
---
>     "created": "2024-02-06T20:56:29Z",
7c7
<       "Tool: ReleaseTools-5b7ef459c76de94be909b02087080b4cc8befeed\n"
---
>       "Tool: ReleaseTools-f39e1557464bc7d14019a88cb8257545ed4104f3\n"
```