### PR TITLE
Add pip to SBOM at release stage

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,1 +1,2 @@
 pytest
+pytest-mock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,6 +23,12 @@ pluggy==1.4.0 \
 pytest==8.0.0 \
     --hash=sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c \
     --hash=sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6
+    # via
+    #   -r dev-requirements.in
+    #   pytest-mock
+pytest-mock==3.12.0 \
+    --hash=sha256:0972719a7263072da3a21c7f4773069bcc7486027d7e8e1f81d98a47e701bc4f \
+    --hash=sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9
     # via -r dev-requirements.in
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,9 +1,10 @@
 import json
+import random
+import hashlib
 import unittest.mock
 
 import pytest
-import random
-import hashlib
+
 import sbom
 
 

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,3 +1,6 @@
+import json
+import unittest.mock
+
 import pytest
 import random
 import hashlib
@@ -58,3 +61,57 @@ def test_normalization():
         "a": [1, 2, 3, {"b": ["c", 4, ["2", 7, True, {}]]}],
         "b": [["a", 1, 2], ["b", 1, 2]]
     }
+
+
+def test_fetch_project_metadata_from_pypi(mocker):
+
+    mock_urlopen = mocker.patch("sbom.urlopen")
+    mock_urlopen.return_value = unittest.mock.Mock()
+
+    # This is only a partial response using the information
+    # that this function uses.
+    mock_urlopen.return_value.read.return_value = json.dumps({
+        "urls": [
+            {
+                "digests": {
+                    "blake2b_256": "94596638090c25e9bc4ce0c42817b5a234e183872a1129735a9330c472cc2056",
+                    "md5": "1331aabb4d1a2677f493effeebda3605",
+                    "sha256": "ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2"
+                },
+                "filename": "pip-24.0.tar.gz",
+                "packagetype": "sdist",
+                "url": "https://files.pythonhosted.org/packages/.../pip-24.0.tar.gz",
+            },
+            {
+                "digests": {
+                    "blake2b_256": "8a6a19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b",
+                    "md5": "74e3c5e4082113b1239ca0e9abfd1e82",
+                    "sha256": "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc"
+                },
+                "filename": "pip-24.0-py3-none-any.whl",
+                "packagetype": "bdist_wheel",
+                "url": "https://files.pythonhosted.org/packages/.../pip-24.0-py3-none-any.whl",
+            }
+        ]
+    }).encode()
+
+    # Default filename is the wheel
+    download_url, checksum_sha256 = sbom.fetch_package_metadata_from_pypi(
+        project="pip",
+        version="24.0",
+    )
+
+    mock_urlopen.assert_called_once_with("https://pypi.org/pypi/pip/24.0/json")
+    assert download_url == "https://files.pythonhosted.org/packages/.../pip-24.0-py3-none-any.whl"
+    assert checksum_sha256 == "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc"
+
+    # If we ask for the sdist (which we don't do normally)
+    # then it'll be returned instead.
+    download_url, checksum_sha256 = sbom.fetch_package_metadata_from_pypi(
+        project="pip",
+        version="24.0",
+        filename="pip-24.0.tar.gz"
+    )
+
+    assert download_url == "https://files.pythonhosted.org/packages/.../pip-24.0.tar.gz"
+    assert checksum_sha256 == "ea9bd1a847e8c5774a5777bb398c19e80bcd4e2aa16a4b301b718fe6f593aba2"


### PR DESCRIPTION
Closes https://github.com/python/release-tools/issues/91 This moves the pip SBOM discovery machinery from the CPython repository to this repository to not require pip maintainers to update the SBOM every time, saving difficulties with backporting and a bunch of manual effort.

There will be a follow-up PR to the CPython repository removing the machinery there once this PR lands.

The SBOM diff between running this script on `Python-3.12.2.tgz`:

```patch
4c4
<     "created": "2024-02-06T20:56:29Z",
---
>     "created": "2024-02-09T17:13:23Z",
7c7
<       "Tool: ReleaseTools-f39e1557464bc7d14019a88cb8257545ed4104f3\n"
---
>       "Tool: ReleaseTools-a5b55c248715c96d4d5207717bc2942a10b4b99d\n"
85980,85984d85979
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-cachecontrol",
<       "relationshipType": "DEPENDS_ON",
85990,85994d85984
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-certifi",
<       "relationshipType": "DEPENDS_ON",
86000,86004d85989
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-chardet",
<       "relationshipType": "DEPENDS_ON",
86010,86014d85994
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-colorama",
<       "relationshipType": "DEPENDS_ON",
86025,86029d86004
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-distlib",
<       "relationshipType": "DEPENDS_ON",
86035,86039d86009
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-distro",
<       "relationshipType": "DEPENDS_ON",
86055,86059d86024
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-idna",
<       "relationshipType": "DEPENDS_ON",
86080,86084d86044
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-msgpack",
<       "relationshipType": "DEPENDS_ON",
86090,86094d86049
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-packaging",
<       "relationshipType": "DEPENDS_ON",
86105,86109d86059
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-platformdirs",
<       "relationshipType": "DEPENDS_ON",
86115,86119d86064
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-pygments",
<       "relationshipType": "DEPENDS_ON",
86125,86129d86069
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-pyparsing",
<       "relationshipType": "DEPENDS_ON",
86135,86139d86074
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-pyproject-hooks",
<       "relationshipType": "DEPENDS_ON",
86145,86149d86079
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-requests",
<       "relationshipType": "DEPENDS_ON",
86155,86159d86084
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-resolvelib",
<       "relationshipType": "DEPENDS_ON",
86165,86169d86089
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-rich",
<       "relationshipType": "DEPENDS_ON",
86175,86179d86094
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-setuptools",
<       "relationshipType": "DEPENDS_ON",
86185,86189d86099
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-six",
<       "relationshipType": "DEPENDS_ON",
86195,86199d86104
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-tenacity",
<       "relationshipType": "DEPENDS_ON",
86205,86209d86109
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-tomli",
<       "relationshipType": "DEPENDS_ON",
86215,86219d86114
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-truststore",
<       "relationshipType": "DEPENDS_ON",
86225,86229d86119
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-typing-extensions",
<       "relationshipType": "DEPENDS_ON",
86235,86239d86124
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-urllib3",
<       "relationshipType": "DEPENDS_ON",
86241,86245d86125
<     },
<     {
<       "relatedSpdxElement": "SPDXRef-PACKAGE-webencodings",
<       "relationshipType": "DEPENDS_ON",
<       "spdxElementId": "SPDXRef-PACKAGE-cpython"
```

Notice this removes all the direct relationships between CPython and pip's subpackages, this is a good thing IMO since CPython doesn't directly depend on these packages. This still lets tools like scanners discover vulnerabilities because CPython still has a dependency relationship with pip.