### PR TITLE
Add SBOMs generation for Windows artifacts

### DIFF
--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -146,6 +146,12 @@ stages:
         ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
           SigningCertificate: ${{ parameters.SigningCertificate }}
 
+  - stage: SBOM
+    displayName: Create SBOMs
+    dependsOn: Build
+    jobs:
+    - template: stage-sbom.yml
+
   - stage: Layout
     displayName: Generate layouts
     dependsOn: Sign
@@ -218,7 +224,7 @@ stages:
     - ${{ if eq(parameters.DoMSI, 'true') }}:
       - stage: PublishPyDotOrg
         displayName: Publish to python.org
-        dependsOn: ['Test_MSI', 'Test']
+        dependsOn: ['SBOM', 'Test_MSI', 'Test']
         jobs:
         - template: stage-publish-pythonorg.yml
 

--- a/windows-release/stage-sbom.yml
+++ b/windows-release/stage-sbom.yml
@@ -1,0 +1,45 @@
+jobs:
+- job: SBOM_Files
+  displayName: Create SBOMs for Python binaries
+
+  pool:
+    vmImage: windows-2022
+
+  workspace:
+    clean: all
+
+  strategy:
+    matrix:
+      win32:
+        Name: win32
+      amd64:
+        Name: amd64
+      arm64:
+        Name: arm64
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.6 or later'
+    inputs:
+      versionSpec: '>=3.6'
+
+  - template: ./checkout.yml
+
+  - task: DownloadPipelineArtifact@1
+    displayName: 'Download artifact: bin_$(Name)'
+    inputs:
+      artifactName: bin_$(Name)
+      targetPath: $(Build.BinariesDirectory)\bin
+
+  - powershell: >
+      python
+      "$(Build.SourcesDirectory)\sbom.py"
+      (gci msi\*\python-*.exe | select -First 1)
+    workingDirectory: $(Build.BinariesDirectory)
+    displayName: 'Create SBOMs for binaries'
+
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish artifact: sbom'
+    inputs:
+      targetPath: '$(Build.BinariesDirectory)\sbom'
+      artifactName: sbom


### PR DESCRIPTION
Requires https://github.com/python/cpython/pull/115789 to be checked in to work.

* Does `checkout.yml` essentially pull CPython's source code into the `release-tools` directory?
* Do the Windows artifacts have pip included? I couldn't find it in `ensurepip` for the embed artifacts
* Is it possible to run Azure Pipelines off of a branch besides `master` so I can test this code before enabling it for future releases?

cc @zooba 