### PR TITLE
Run Windows installer tests in their own container

### DIFF
--- a/windows-release/stage-test-msi.yml
+++ b/windows-release/stage-test-msi.yml
@@ -54,10 +54,10 @@ jobs:
 
   - powershell: >
       docker run --rm
-      -v "$(Build.BinariesDirectory)\msi:C:\msi"
-      -v "$(Build.SourcesDirectory)\windows-release:C:\scripts"
-      -v ('{0}:C:\Python' -f (mkdir "$(Build.BinariesDirectory)\tmp"))
-      -v ('{0}:C:\logs' -f (mkdir "$(Build.ArtifactStagingDirectory)\logs"))
+      -v ('{0}:C:\msi' -f (Split-Path -Parent "$(SetupExe)"))
+      -v ('{0}:C:\scripts' -f (gi windows-release))
+      -v ('{0}:C:\Python' -f (mkdir "$(Build.BinariesDirectory)\tmp" -Force))
+      -v ('{0}:C:\logs' -f (mkdir "$(Build.ArtifactStagingDirectory)\logs" -Force))
       -e InstallAllUsers
       -e IncludeFreethreadedOpt
       -e SkipTests

--- a/windows-release/stage-test-msi.yml
+++ b/windows-release/stage-test-msi.yml
@@ -56,7 +56,7 @@ jobs:
       docker run --rm
       -v "$(Build.BinariesDirectory)\msi:C:\msi"
       -v "$(Build.SourcesDirectory)\windows-release:C:\scripts"
-      -v "$(Build.BinariesDirectory)\tmp:C:\Python"
+      -v ('{0}:C:\Python' -f (mkdir "$(Build.BinariesDirectory)\tmp"))
       -v ('{0}:C:\logs' -f (mkdir "$(Build.ArtifactStagingDirectory)\logs"))
       -e InstallAllUsers
       -e IncludeFreethreadedOpt

--- a/windows-release/stage-test-msi.yml
+++ b/windows-release/stage-test-msi.yml
@@ -57,7 +57,7 @@ jobs:
       -v "$(Build.BinariesDirectory)\msi:C:\msi"
       -v "$(Build.SourcesDirectory)\windows-release:C:\scripts"
       -v "$(Build.BinariesDirectory)\tmp:C:\Python"
-      -v ('{}:C:\logs' -f (mkdir "$(Build.ArtifactStagingDirectory)\logs"))
+      -v ('{0}:C:\logs' -f (mkdir "$(Build.ArtifactStagingDirectory)\logs"))
       -e InstallAllUsers
       -e IncludeFreethreadedOpt
       -e SkipTests

--- a/windows-release/stage-test-msi.yml
+++ b/windows-release/stage-test-msi.yml
@@ -57,7 +57,7 @@ jobs:
       -v ('{0}:C:\msi' -f (Split-Path -Parent "$(SetupExe)"))
       -v ('{0}:C:\scripts' -f (gi windows-release))
       -v ('{0}:C:\Python' -f (mkdir "$(Build.BinariesDirectory)\tmp" -Force))
-      -v ('{0}:C:\logs' -f (mkdir "$(Build.ArtifactStagingDirectory)\logs" -Force))
+      -v ('{0}:C:\logs' -f (mkdir "$(Logs)" -Force))
       -e InstallAllUsers
       -e IncludeFreethreadedOpt
       -e SkipTests

--- a/windows-release/stage-test-msi.yml
+++ b/windows-release/stage-test-msi.yml
@@ -37,7 +37,7 @@ jobs:
         InstallAllUsers: 1
 
   steps:
-  - checkout: none
+  - checkout: self
 
   - task: DownloadPipelineArtifact@1
     displayName: 'Download artifact: msi'
@@ -52,90 +52,19 @@ jobs:
     displayName: 'Find installer executable'
     workingDirectory: $(Build.BinariesDirectory)\msi
 
-  - script: >
-      "$(SetupExe)"
-      /passive
-      /log "$(Logs)\install\log.txt"
-      TargetDir="$(Build.BinariesDirectory)\Python"
-      Include_debug=1
-      Include_symbols=1
-      InstallAllUsers=$(InstallAllUsers)
-      $(IncludeFreethreadedOpt)
-    displayName: 'Install Python'
-
-  - powershell: |
-      gci "$(Build.BinariesDirectory)\python"
-    displayName: 'List installed files'
-
-  - powershell: |
-      $p = gi "$(Build.BinariesDirectory)\Python\python.exe"
-      Write-Host "##vso[task.prependpath]$(Split-Path -Parent $p)"
-    displayName: 'Add test Python to PATH'
-
-  - script: |
-      python -c "import sys; print(sys.version)"
-    displayName: 'Collect version number'
-    condition: and(succeeded(), not(variables['SkipTests']))
-
-  - script: |
-      python -m site
-    displayName: 'Collect site'
-    condition: and(succeeded(), not(variables['SkipTests']))
-
-  - ${{ if eq(parameters.DoFreethreaded, 'true') }}:
-    - powershell: |
-        $p = (gci "$(Build.BinariesDirectory)\Python\python3*t.exe" | select -First 1)
-        Write-Host "Found $p"
-        if (-not $p) {
-            Write-Host "Did not find python3*t.exe in:"
-            dir "$(Build.BinariesDirectory)\Python"
-            throw "Free-threaded binaries were not installed"
-        } else {
-            & $p -c "import sys; print(sys.version)"
-        }
-      displayName: 'Collect free-threaded version number'
-      condition: and(succeeded(), not(variables['SkipTests']))
-
-  - powershell: |
-      gci -r "${env:PROGRAMDATA}\Microsoft\Windows\Start Menu\Programs\Python*"
-    displayName: 'Capture per-machine Start Menu items'
-  - powershell: |
-      gci -r "${env:APPDATA}\Microsoft\Windows\Start Menu\Programs\Python*"
-    displayName: 'Capture per-user Start Menu items'
-
-  - powershell: |
-      gci -r "HKLM:\Software\WOW6432Node\Python"
-    displayName: 'Capture per-machine 32-bit registry'
-  - powershell: |
-      gci -r "HKLM:\Software\Python"
-    displayName: 'Capture per-machine native registry'
-  - powershell: |
-      gci -r "HKCU:\Software\Python"
-    displayName: 'Capture current-user registry'
-
-  - script: |
-      python -m pip install "azure<0.10"
-      python -m pip uninstall -y azure python-dateutil six
-    displayName: 'Test (un)install package'
-    condition: and(succeeded(), not(variables['SkipTests']))
-
-  - powershell: |
-      if (Test-Path -Type Container "$(Build.BinariesDirectory)\Python\Lib\test\test_ttk") {
-        # New set of tests (3.12 and later)
-        python -m test -uall -v test_ttk test_tkinter test_idle
-      } else {
-        # Old set of tests
-        python -m test -uall -v test_ttk_guionly test_tk test_idle
-      }
-    displayName: 'Test Tkinter and Idle'
-    condition: and(succeeded(), not(variables['SkipTests']), not(variables['SkipTkTests']))
-
-  - script: >
-      "$(SetupExe)"
-      /passive
-      /uninstall
-      /log "$(Logs)\uninstall\log.txt"
-    displayName: 'Uninstall Python'
+  - powershell: >
+      docker run --rm
+      -v "$(Build.BinariesDirectory)\msi:C:\msi"
+      -v "$(Build.SourcesDirectory)\windows-release:C:\scripts"
+      -v "$(Build.BinariesDirectory)\tmp:C:\Python"
+      -v ('{}:C:\logs' -f (mkdir "$(Build.ArtifactStagingDirectory)\logs"))
+      -e InstallAllUsers
+      -e IncludeFreethreadedOpt
+      -e SkipTests
+      -e SkipTkTests
+      mcr.microsoft.com/windows/servercore:ltsc2022
+      powershell C:\scripts\test-msi.ps1 "C:\msi\$(SetupExeName)"
+    displayName: 'Run installer tests'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'

--- a/windows-release/test-msi.ps1
+++ b/windows-release/test-msi.ps1
@@ -27,16 +27,24 @@ dir -r "${env:APPDATA}\Microsoft\Windows\Start Menu\Programs\Python*"
 
 Write-Host "##[section]Capture registry"
 Write-Host 'Capture per-machine 32-bit registry'
-Write-Host "##[command]dir -r ""HKLM:\Software\WOW6432Node\Python"""
-dir -r "HKLM:\Software\WOW6432Node\Python"
+# PS 5.0 and later can't do this, because they normalise registry paths incorrectly
+# So we'll use the good old "reg" tool
+#Write-Host "##[command]dir -r ""HKLM:\Software\WOW6432Node\Python"""
+#dir -r "HKLM:\Software\WOW6432Node\Python"
+Write-Host "##[command]reg HKLM\Software\Python /s /reg:32"
+reg HKLM\Software\Python /s /reg:32
 
 Write-Host 'Capture per-machine native registry'
-Write-Host "##[command]dir -r ""HKLM:\Software\Python"""
-dir -r "HKLM:\Software\Python"
+#Write-Host "##[command]dir -r ""HKLM:\Software\Python"""
+#dir -r "HKLM:\Software\Python"
+Write-Host "##[command]reg HKLM\Software\Python /s /reg:64"
+reg HKLM\Software\Python /s /reg:64
 
 Write-Host 'Capture current-user registry'
-Write-Host "##[command]dir -r ""HKCU:\Software\Python"""
-dir -r "HKCU:\Software\Python"
+#Write-Host "##[command]dir -r ""HKCU:\Software\Python"""
+#dir -r "HKCU:\Software\Python"
+Write-Host "##[command]reg HKCU\Software\Python /s"
+reg HKCU\Software\Python /s
 
 
 if (-not $env:SkipTests) {

--- a/windows-release/test-msi.ps1
+++ b/windows-release/test-msi.ps1
@@ -1,14 +1,15 @@
 param ([string]$SetupExe)
 
 Write-Host "##[section]Install Python"
-$SetupCmd = "$SetupExe /passive /log ""C:\Logs\install\log.txt"" " + `
+$SetupArgs = "$SetupExe " + `
+            "/passive /log ""C:\Logs\install\log.txt"" " + `
             "TargetDir=C:\Python " + `
             "Include_debug=1 " + `
             "Include_symbols=1 " + `
             "InstallAllUsers=${env:InstallAllUsers} " + `
             "${env:IncludeFreethreadedOpt}"
 Write-Host "##[command]$SetupCmd"
-& $SetupCmd
+iex $SetupCmd
 if (!$?) { exit $LASTEXITCODE }
 
 Write-Host "##[command]dir C:\Python"
@@ -87,5 +88,5 @@ if (-not $env:SkipTests) {
 Write-Host "##[section]Uninstall Python"
 $UninstallCmd = "$(SetupExe) /passive /uninstall /log C:\Logs\uninstall\log.txt"
 Write-Host "##[command]$UninstallCmd"
-& $UninstallCmd
+iex $UninstallCmd
 if (!$?) { exit $LASTEXITCODE }

--- a/windows-release/test-msi.ps1
+++ b/windows-release/test-msi.ps1
@@ -10,7 +10,7 @@ $SetupArgs = "$SetupExe " + `
             "${env:IncludeFreethreadedOpt}"
 Write-Host "##[command]$SetupCmd"
 iex $SetupCmd
-if (!$?) { exit $LASTEXITCODE }
+if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
 Write-Host "##[command]dir C:\Python"
 dir C:\Python
@@ -89,4 +89,4 @@ Write-Host "##[section]Uninstall Python"
 $UninstallCmd = "$(SetupExe) /passive /uninstall /log C:\Logs\uninstall\log.txt"
 Write-Host "##[command]$UninstallCmd"
 iex $UninstallCmd
-if (!$?) { exit $LASTEXITCODE }
+if ($LASTEXITCODE) { exit $LASTEXITCODE }

--- a/windows-release/test-msi.ps1
+++ b/windows-release/test-msi.ps1
@@ -1,0 +1,91 @@
+param ([string]$SetupExe)
+
+Write-Host "##[section]Install Python"
+$SetupCmd = "$SetupExe /passive /log ""C:\Logs\install\log.txt"" "`
+            "TargetDir=C:\Python " `
+            "Include_debug=1 " `
+            "Include_symbols=1 " `
+            "InstallAllUsers=${env:InstallAllUsers} " `
+            "${env:IncludeFreethreadedOpt}"
+Write-Host "##[command]$SetupCmd"
+& $SetupCmd
+if (!$?) { exit $LASTEXITCODE }
+
+Write-Host "##[command]dir C:\Python"
+dir C:\Python
+
+$env:PATH = "C:\Python:${env:PATH}"
+
+
+Write-Host "##[section]Capture Start Menu items"
+Write-Host "##[command]dir -r ""${env:PROGRAMDATA}\Microsoft\Windows\Start Menu\Programs\Python*"""
+dir -r "${env:PROGRAMDATA}\Microsoft\Windows\Start Menu\Programs\Python*"
+
+Write-Host "##[command]dir -r ""${env:APPDATA}\Microsoft\Windows\Start Menu\Programs\Python*"""
+dir -r "${env:APPDATA}\Microsoft\Windows\Start Menu\Programs\Python*"
+
+Write-Host "##[section]Capture registry"
+Write-Host 'Capture per-machine 32-bit registry'
+Write-Host "##[command]dir -r ""HKLM:\Software\WOW6432Node\Python"""
+dir -r "HKLM:\Software\WOW6432Node\Python"
+
+Write-Host 'Capture per-machine native registry'
+Write-Host "##[command]dir -r ""HKLM:\Software\Python"""
+dir -r "HKLM:\Software\Python"
+
+Write-Host 'Capture current-user registry'
+Write-Host "##[command]dir -r ""HKCU:\Software\Python"""
+dir -r "HKCU:\Software\Python"
+
+
+if (-not $env:SkipTests) {
+    Write-Host "##[section]Smoke tests"
+    Write-Host "##[command]python -c ""import sys; print(sys.version)"""
+    python -c "import sys; print(sys.version)"
+    if (!$?) { exit $LASTEXITCODE }
+    Write-Host "##[command]python -m site"
+    python -m site
+    if (!$?) { exit $LASTEXITCODE }
+
+    if ($env:IncludeFreethreadedOpt) {
+        $p = (gci "C:\Python\python3*t.exe" | select -First 1)
+        if (-not $p) {
+            Write-Host "Did not find python3*t.exe in:"
+            dir "C:\Python"
+            throw "Free-threaded binaries were not installed"
+        }
+        Write-Host "Found free threaded executable $p"
+        Write-Host "##[command]$p -c ""import sys; print(sys.version)"""
+        & $p -c "import sys; print(sys.version)"
+        if (!$?) { exit $LASTEXITCODE }
+    }
+
+    Write-Host "##[section]Test (un)install package"
+    Write-Host "##[command]python -m pip install ""azure<0.10"""
+    python -m pip install "azure<0.10"
+    if (!$?) { exit $LASTEXITCODE }
+    Write-Host "##[command]python -m pip uninstall -y azure python-dateutil six"
+    python -m pip uninstall -y azure python-dateutil six
+    if (!$?) { exit $LASTEXITCODE }
+
+    if (-not $env:SkipTkTests) {
+        Write-Host "##[section]Test Tkinter and Idle"
+        if (Test-Path -Type Container "C:\Python\Lib\test\test_ttk") {
+            # New set of tests (3.12 and later)
+            Write-Host "##[command]python -m test -uall -v test_ttk test_tkinter test_idle"
+            python -m test -uall -v test_ttk test_tkinter test_idle
+            if (!$?) { exit $LASTEXITCODE }
+        } else {
+            # Old set of tests
+            Write-Host "##[command]python -m test -uall -v test_ttk_guionly test_tk test_idle"
+            python -m test -uall -v test_ttk_guionly test_tk test_idle
+            if (!$?) { exit $LASTEXITCODE }
+        }
+    }
+}
+
+Write-Host "##[section]Uninstall Python"
+$UninstallCmd = "$(SetupExe) /passive /uninstall /log C:\Logs\uninstall\log.txt"
+Write-Host "##[command]$UninstallCmd"
+& $UninstallCmd
+if (!$?) { exit $LASTEXITCODE }

--- a/windows-release/test-msi.ps1
+++ b/windows-release/test-msi.ps1
@@ -1,11 +1,11 @@
 param ([string]$SetupExe)
 
 Write-Host "##[section]Install Python"
-$SetupCmd = "$SetupExe /passive /log ""C:\Logs\install\log.txt"" "`
-            "TargetDir=C:\Python " `
-            "Include_debug=1 " `
-            "Include_symbols=1 " `
-            "InstallAllUsers=${env:InstallAllUsers} " `
+$SetupCmd = "$SetupExe /passive /log ""C:\Logs\install\log.txt"" " + `
+            "TargetDir=C:\Python " + `
+            "Include_debug=1 " + `
+            "Include_symbols=1 " + `
+            "InstallAllUsers=${env:InstallAllUsers} " + `
             "${env:IncludeFreethreadedOpt}"
 Write-Host "##[command]$SetupCmd"
 & $SetupCmd

--- a/windows-release/test-msi.ps1
+++ b/windows-release/test-msi.ps1
@@ -1,7 +1,7 @@
 param ([string]$SetupExe)
 
 Write-Host "##[section]Install Python"
-$SetupArgs = "$SetupExe " + `
+$SetupCmd = "$SetupExe " + `
             "/passive /log ""C:\Logs\install\log.txt"" " + `
             "TargetDir=C:\Python " + `
             "Include_debug=1 " + `


### PR DESCRIPTION
This makes each install test run in its own container, isolated from the build machine, which allows us to test versions of Python that are already installed on the build machine.

Unfortunately, it seems that Windows Installer does not work properly inside the container, so we can't actually use it.

Posting it here for posterity, or in case someone comes up with a way to make it work.