### PR TITLE
Fix for spaces in EDITOR env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
           python-version: 3.x
       - run: |
           python -m pip install -r dev-requirements.txt
+      - run: |
           pytest tests/

--- a/release.py
+++ b/release.py
@@ -215,8 +215,9 @@ def bump(tag):
     print('Please commit and use --tag')
 
 
-def manual_edit(fn):
-    run_cmd([os.environ["EDITOR"], fn])
+def manual_edit(fn: str) -> None:
+    editor = os.environ["EDITOR"].split()
+    run_cmd([*editor, fn])
 
 
 @contextmanager

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,28 @@
+import pytest
+from pytest_mock import MockerFixture
+
+import release
+
+
+@pytest.mark.parametrize(
+    ["test_editor", "expected"],
+    [
+        ("vim", ["vim", "README.rst"]),
+        ("bbedit --wait", ["bbedit", "--wait", "README.rst"]),
+    ],
+)
+def test_manual_edit(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    test_editor: str,
+    expected: list[str],
+) -> None:
+    # Arrange
+    monkeypatch.setenv("EDITOR", test_editor)
+    mock_run_cmd = mocker.patch("release.run_cmd")
+
+    # Act
+    release.manual_edit("README.rst")
+
+    # Assert
+    mock_run_cmd.assert_called_once_with(expected)


### PR DESCRIPTION
When there's a space in `$EDITOR`:

```console
❯ echo $EDITOR
bbedit --wait
```

`release.py` fails with `FileNotFoundError: [Errno 2] No such file or directory: 'bbedit --wait'`:

```pytb
...
Edit README.rst
Executing ['bbedit --wait', 'README.rst']
Traceback (most recent call last):
  File "/Users/hugo/github/python/cpython/main/../release-tools/release.py", line 539, in <module>
    main(sys.argv)
  File "/Users/hugo/github/python/cpython/main/../release-tools/release.py", line 527, in main
    bump(tag)
  File "/Users/hugo/github/python/cpython/main/../release-tools/release.py", line 208, in bump
    manual_edit(fn)
  File "/Users/hugo/github/python/cpython/main/../release-tools/release.py", line 219, in manual_edit
    run_cmd([os.environ["EDITOR"], fn])
  File "/Users/hugo/github/python/cpython/main/../release-tools/release.py", line 46, in run_cmd
    subprocess.check_call(cmd, shell=shell, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 408, in check_call
    retcode = call(*popenargs, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 389, in call
    with Popen(*popenargs, **kwargs) as p:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 1953, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'bbedit --wait'
```

It should be calling `subprocess.check_call` with `['bbedit', '--wait', 'README.rst']` instead of `['bbedit --wait', 'README.rst']`.

Fix it, with tests.
