### PR TITLE
Triple lint YAML

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/source-and-docs-release.yml
+++ b/.github/workflows/source-and-docs-release.yml
@@ -22,6 +22,12 @@ jobs:
   source-and-docs:
     runs-on: ubuntu-22.04
     steps:
+      - name: "Workflow run information"
+        run: |
+          echo "git_remote: ${{ inputs.git_remote }}"
+          echo "git_commit: ${{ inputs.git_commit }}"
+          echo "cpython_release: ${{ inputs.cpython_release }}"
+
       - name: "Checkout python/release-tools"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/source-and-docs-release.yml
+++ b/.github/workflows/source-and-docs-release.yml
@@ -81,7 +81,7 @@ jobs:
           tar xvf Python-${{ inputs.cpython_release }}.tgz
           cd Python-${{ inputs.cpython_release }}
 
-          ./configure --prefix=$(realpath '../installation/')
+          ./configure "--prefix=$(realpath '../installation/')"
           make -j
           make install -j
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+        exclude: windows-release/azure-pipelines.yml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: trailing-whitespace
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.1
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.27
+    hooks:
+      - id: actionlint
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
Follow on from https://github.com/python/release-tools/pull/104.

Before that fix, the "Upload the docs artifacts" step was being skipped:

https://github.com/python/release-tools/actions/runs/8519755747/job/23334443184

Linting with https://github.com/rhysd/actionlint:

```console
❯ actionlint
.github/workflows/source-and-docs-release.yml:71:9: shellcheck reported issue in this script: SC2046:warning:7:22: Quote this to prevent word splitting [shellcheck]
   |
71 |         run: |
   |         ^~~~
.github/workflows/source-and-docs-release.yml:96:13: if: condition "${{ hashFiles('cpython/${{ inputs.cpython_release }}/docs') != '' }}" is always evaluated to true because extra characters are around ${{ }} [if-cond]
   |
96 |         if: ${{ hashFiles('cpython/${{ inputs.cpython_release }}/docs') != '' }}
   |             ^~~
```

That second one was the problem: it doesn't like the `${{ inputs.cpython_release }` inside a string: 'cpython/${{ inputs.cpython_release }}/docs' (try in the [playground](https://rhysd.github.io/actionlint)).

See:

* https://github.com/orgs/community/discussions/25761#discussioncomment-6306201

Let's also fix that shellcheck warning, and add _three_ YAML linters to the CI to help prevent this :)  Plus some other handy linters.
