### PR TITLE
Separate source and documentation builds

### DIFF
--- a/.github/workflows/source-and-docs-release.yml
+++ b/.github/workflows/source-and-docs-release.yml
@@ -19,7 +19,7 @@ on:
 name: "Build Python source and docs artifacts"
 
 jobs:
-  build-source-and-docs:
+  verify-input:
     runs-on: ubuntu-22.04
     steps:
       - name: "Workflow run information"
@@ -27,9 +27,6 @@ jobs:
           echo "git_remote: ${{ inputs.git_remote }}"
           echo "git_commit: ${{ inputs.git_commit }}"
           echo "cpython_release: ${{ inputs.cpython_release }}"
-
-      - name: "Checkout python/release-tools"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: "Checkout ${{ inputs.git_remote }}/cpython"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -45,6 +42,21 @@ jobs:
             exit 1
           fi
 
+  build-source:
+    runs-on: ubuntu-22.04
+    needs:
+      - verify-input
+    steps:
+      - name: "Checkout python/release-tools"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: "Checkout ${{ inputs.git_remote }}/cpython"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: "${{ inputs.git_remote }}/cpython"
+          ref: "v${{ inputs.cpython_release }}"
+          path: "cpython"
+
       - name: "Setup Python"
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
@@ -54,19 +66,6 @@ jobs:
         run: |
           python -m pip install --no-deps \
             -r requirements.txt
-
-      - name: "Install docs dependencies"
-        # Docs aren't built for alpha or beta releases.
-        if: ${{ !(contains(inputs.cpython_release, 'a') || contains(inputs.cpython_release, 'b')) }}
-        run: |
-          python -m pip install \
-            -r cpython/Doc/requirements.txt
-
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            latexmk texlive-xetex xindy texinfo texlive-latex-base \
-            texlive-fonts-recommended texlive-fonts-extra \
-            texlive-full
 
       - name: "Build Python release artifacts"
         run: |
@@ -80,20 +79,53 @@ jobs:
           path: |
             cpython/${{ inputs.cpython_release }}/src
 
+  build-docs:
+    runs-on: ubuntu-22.04
+    needs:
+      - verify-input
+
+    # Docs aren't built for alpha or beta releases.
+    if: ${{ !(contains(inputs.cpython_release, 'a') || contains(inputs.cpython_release, 'b')) }}
+
+    steps:
+      - name: "Checkout ${{ inputs.git_remote }}/cpython"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: "${{ inputs.git_remote }}/cpython"
+          ref: "v${{ inputs.cpython_release }}"
+
+      - name: "Setup Python"
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: 3.11
+
+      - name: "Install docs dependencies"
+        run: |
+          python -m pip install \
+            -r Doc/requirements.txt
+
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            latexmk texlive-xetex xindy texinfo texlive-latex-base \
+            texlive-fonts-recommended texlive-fonts-extra \
+            texlive-full
+
+      - name: "Build docs"
+        run: |
+          cd Doc
+          SPHINXOPTS="-j10" make dist
+
       - name: "Upload the docs artifacts"
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        # Conditionally run this step if there is a 'docs/' directory.
-        # Docs aren't built for alpha or beta releases.
-        if: ${{ hashFiles(format('cpython/{0}/docs', inputs.cpython_release)) != '' }}
         with:
           name: docs
           path: |
-            cpython/${{ inputs.cpython_release }}/docs
+            Doc/dist/
 
   test-source:
     runs-on: ubuntu-22.04
     needs:
-      - build-source-and-docs
+      - build-source
     steps:
       - name: "Download the source artifacts"
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4

--- a/release.py
+++ b/release.py
@@ -315,8 +315,8 @@ def export(tag, silent=False):
             # build docs *before* we do "blurb export"
             # because docs now depend on Misc/NEWS.d
             # and we remove Misc/NEWS.d as part of cleanup for export
-            if tag.is_final or tag.level == 'rc':
-                docdist = build_docs()
+            # if tag.is_final or tag.level == 'rc':
+            #     docdist = build_docs()
 
             print('Using blurb to build Misc/NEWS')
             run_cmd(["blurb", "merge"], silent=silent)
@@ -337,8 +337,8 @@ def export(tag, silent=False):
             for name in ('.azure-pipelines', '.git', '.github', '.hg'):
                 shutil.rmtree(name, ignore_errors=True)
 
-        if tag.is_final or tag.level == 'rc':
-            shutil.copytree(docdist, 'docs')
+        # if tag.is_final or tag.level == 'rc':
+        #     shutil.copytree(docdist, 'docs')
 
         with pushd(os.path.join(archivename, 'Doc')):
             print('Removing doc build artifacts')


### PR DESCRIPTION
This PR separates the builds for the source artifacts and documentation into separate jobs. The primary motivation is that the docs builds require pulling many more (mostly unpinned) dependencies from PyPI and apt in order to generate the documentation whereas the source artifacts which have higher integrity requirements require far fewer, pinned, dependencies.

Originally when I looked at this problem it seems somewhat difficult because the docs builds and source builds shared a build script, but after [running all of the current release streams](https://github.com/python/release-tools/issues/74#issuecomment-2079425442) I'm not sure why the script has the docs build step as a part of the source build step. All builds seemed to succeed without building the docs and source together.

If it's possible to remove the docs build from `release.py --export` then I can update the commit and merge this PR.

Closes #74 

