### PR TITLE
Lint PowerShell scripts with PSScriptAnalyzer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,8 @@ jobs:
           python-version: "3.x"
           cache: pip
       - uses: pre-commit/action@v3.0.1
+
+      - name: Run PSScriptAnalyzer on PowerShell scripts
+        shell: pwsh
+        run: |
+          Invoke-ScriptAnalyzer -Path . -Recurse -Severity ParseError,Error -EnableExit


### PR DESCRIPTION
To hopefully find things like https://github.com/python/release-tools/pull/124 in PRs rather than at the end of a two-hour release build.

Without the fix, fails like:

```
RuleName                            Severity     ScriptName Line  Message
--------                            --------     ---------- ----  -------
MissingEndParenthesisInFunctionPara ParseError   uploadrele 32    Missing ')' i
meterList                                        ase.ps1          n function pa
                                                                  rameter list.
UnexpectedToken                     ParseError   uploadrele 34    Unexpected to
                                                 ase.ps1          ken ')' in ex
                                                                  pression or s
                                                                  tatement.
Error: Process completed with exit code 2.
```

https://github.com/hugovk/release-tools/actions/runs/9003489720/job/24734231897

Thanks to https://horrell.ca/running-psscriptanalyzer-in-github-actions/