### PR TITLE
Fix name of Whats New file

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -960,7 +960,7 @@ def maybe_prepare_new_main_branch(db: DbfilenameShelf) -> None:
 
     prev_branch = f"{release_tag.major}.{release_tag.minor}"
     new_branch = f"{release_tag.major}.{int(release_tag.minor)+1}"
-    whatsnew_file = f"Doc/whatsnew/{new_branch}"
+    whatsnew_file = f"Doc/whatsnew/{new_branch}.rst"
     with cd(db["git_repo"]), open(whatsnew_file, "w") as f:
         f.write(WHATS_NEW_TEMPLATE.format(version=new_branch, prev_version=prev_branch))
 


### PR DESCRIPTION
See python/cpython#118770. We should also add the file to the toctree (https://github.com/python/cpython/pull/118770/commits/e232ea1fc837e2c8f72e7240987abd09c21e2707), which we could do with some search/replace on the index.rst file.