### PR TITLE
Restore the order of pip options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements.txt requirements.in
 #
+--only-binary :all:
 --no-binary grapheme
 --no-binary grpclib
---only-binary :all:
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \


### PR DESCRIPTION
This makes `--no-binary grapheme` effective.

This partially reverts 28583c1168939394ba72105a5801fd12f23df64e,
and restores c9f4eca9fb7b6c2d0eed9bf0c929fceb6e4b1d42.

I've only tested locally with `pip install -r requirements.txt`.