### PR TITLE
Add type hints to `run_release.py`

### DIFF
--- a/buildbotapi.py
+++ b/buildbotapi.py
@@ -35,7 +35,7 @@ class Build:
     def __eq__(self, other):
         return self.id == other.id
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.id)
 
 
@@ -108,7 +108,7 @@ class BuildBotAPI:
         )
         return build
 
-    async def get_recent_failures(self, limit=100):
+    async def get_recent_failures(self, limit: int = 100) -> set[Build]:
         data = await self._fetch_json(
             f"https://buildbot.python.org/all/api/v2/builds?"
             f"complete__eq=true&&results__eq=2&&"

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,5 +1,5 @@
-aiohttp
+aiohttp==3.9.4
 mypy==1.10
 pytest
 pytest-mock
-sigstore
+sigstore==1.1.2

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,3 +1,5 @@
+aiohttp
 mypy==1.10
 pytest
 pytest-mock
+sigstore

--- a/run_release.py
+++ b/run_release.py
@@ -4,6 +4,7 @@
 
 Original code by Pablo Galindo
 """
+from __future__ import annotations
 
 import argparse
 import asyncio
@@ -23,7 +24,7 @@ import time
 import urllib.request
 from dataclasses import dataclass
 from shelve import DbfilenameShelf
-from typing import Callable, Iterator, List, Optional
+from typing import Callable, Iterator
 
 import aiohttp
 import gnupg
@@ -195,13 +196,13 @@ class ReleaseException(Exception):
 class ReleaseDriver:
     def __init__(
         self,
-        tasks: List[Task],
+        tasks: list[Task],
         *,
         release_tag: release_mod.Tag,
         git_repo: str,
         api_key: str,
         ssh_user: str,
-        first_state: Optional[Task] = None,
+        first_state: Task | None = None,
     ) -> None:
         self.tasks = tasks
         dbfile = pathlib.Path.home() / ".python_release"
@@ -212,7 +213,7 @@ class ReleaseDriver:
             self.db.close()
             self.db = shelve.open(str(dbfile), "n")
 
-        self.current_task: Optional[Task] = first_state
+        self.current_task: Task | None = first_state
         self.completed_tasks = self.db.get("completed_tasks", [])
         self.remaining_tasks = iter(tasks[len(self.completed_tasks) :])
         if self.db.get("gpg_key"):

--- a/sbom.py
+++ b/sbom.py
@@ -23,6 +23,7 @@ import sys
 import tarfile
 import typing
 import zipfile
+from typing import Any
 from urllib.request import urlopen
 
 
@@ -118,13 +119,13 @@ def get_release_tools_commit_sha() -> str:
     return stdout
 
 
-def normalize_sbom_data(sbom_data):
+def normalize_sbom_data(sbom_data: dict[str, Any]) -> None:
     """
     Normalize SBOM data in-place by recursion
     and sorting lists by some repeatable key.
     """
 
-    def recursive_sort_in_place(value):
+    def recursive_sort_in_place(value: list | dict) -> None:
         if isinstance(value, list):
             # We need to recurse first so bottom-most elements are sorted first.
             for item in value:
@@ -338,7 +339,7 @@ def create_cpython_sbom(
     sbom_data: dict[str, typing.Any],
     cpython_version: str,
     artifact_path: str,
-):
+) -> None:
     """Creates the top-level SBOM metadata and the CPython SBOM package."""
 
     cpython_version_without_suffix = re.match(r"^([0-9.]+)", cpython_version).group(1)
@@ -412,7 +413,7 @@ def create_cpython_sbom(
     sbom_data["packages"].append(sbom_cpython_package)
 
 
-def create_sbom_for_source_tarball(tarball_path: str):
+def create_sbom_for_source_tarball(tarball_path: str) -> dict[str, Any]:
     """Stitches together an SBOM for a source tarball"""
     tarball_name = os.path.basename(tarball_path)
 
@@ -567,7 +568,9 @@ def create_sbom_for_source_tarball(tarball_path: str):
     return sbom_data
 
 
-def create_sbom_for_windows_artifact(artifact_path, cpython_source_dir: str):
+def create_sbom_for_windows_artifact(
+    artifact_path: str, cpython_source_dir: str
+) -> dict[str, Any]:
     artifact_name = os.path.basename(artifact_path)
     cpython_version = re.match(
         r"^python-([0-9abrc.]+)(?:-|\.exe|\.zip)", artifact_name


### PR DESCRIPTION
For https://github.com/python/release-tools/issues/114.

If temporarily removing `run_release.py` from the mypy exclude list, this fixes 57% of the errors:

```
Found 133 errors in 3 files (checked 6 source files)
```
->
```
Found 76 errors in 3 files (checked 6 source files)
```
