### PR TITLE
Fix getting GitHub owner for remote origin with https://

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ exclude = [
   "^run_release.py$",
   "^sbom.py$",
   "^tests/test_release_tag.py$",
+  "^tests/test_run_release.py$",
   "^tests/test_sbom.py$",
   "^windows-release/purge.py$",
 ]

--- a/run_release.py
+++ b/run_release.py
@@ -739,8 +739,8 @@ def unpack_docs_in_the_docs_server(db: DbfilenameShelf) -> None:
 
 
 def extract_github_owner(url: str) -> str:
-    if https_match := re.match(r"github\.com/([^/]+)/", url):
-        return https_match.group(1)
+    if https_match := re.match(r"(https://)?github\.com/([^/]+)/", url):
+        return https_match.group(2)
     elif ssh_match := re.match(r"^git@github\.com:([^/]+)/", url):
         return ssh_match.group(1)
     else:

--- a/run_release.py
+++ b/run_release.py
@@ -738,6 +738,17 @@ def unpack_docs_in_the_docs_server(db: DbfilenameShelf) -> None:
     execute_command(f"find {destination} -type f -exec chmod 664 {{}} \\;")
 
 
+def extract_github_owner(url: str) -> str:
+    if https_match := re.match(r"github\.com/([^/]+)/", url):
+        return https_match.group(1)
+    elif ssh_match := re.match(r"^git@github\.com:([^/]+)/", url):
+        return ssh_match.group(1)
+    else:
+        raise ReleaseException(
+            f"Could not parse GitHub owner from 'origin' remote URL: {url}"
+        )
+
+
 def start_build_of_source_and_docs(db: DbfilenameShelf) -> None:
     # Get the git commit SHA for the tag
     commit_sha = (
@@ -757,14 +768,7 @@ def start_build_of_source_and_docs(db: DbfilenameShelf) -> None:
         .decode()
         .strip()
     )
-    if https_match := re.match(r"github\.com/([^/]+)/", origin_remote_url):
-        origin_remote_github_owner = https_match.group(1)
-    elif ssh_match := re.match(r"^git@github\.com:([^/]+)/", origin_remote_url):
-        origin_remote_github_owner = ssh_match.group(1)
-    else:
-        raise ReleaseException(
-            f"Could not parse GitHub owner from 'origin' remote URL: {origin_remote_url}"
-        )
+    origin_remote_github_owner = extract_github_owner(origin_remote_url)
     # We ask for human verification at this point since this commit SHA is 'locked in'
     print()
     print(

--- a/tests/test_run_release.py
+++ b/tests/test_run_release.py
@@ -1,0 +1,23 @@
+import pytest
+
+import run_release
+
+
+@pytest.mark.parametrize(
+    ["url", "expected"],
+    [
+        ("github.com/hugovk/cpython.git", "hugovk"),
+        ("git@github.com:hugovk/cpython.git", "hugovk"),
+    ],
+)
+def test_extract_github_owner(url: str, expected: str) -> None:
+    assert run_release.extract_github_owner(url) == expected
+
+
+def test_invalid_extract_github_owner() -> None:
+    with pytest.raises(
+        run_release.ReleaseException,
+        match="Could not parse GitHub owner from 'origin' remote URL: "
+        "https://example.com",
+    ):
+        run_release.extract_github_owner("https://example.com")

--- a/tests/test_run_release.py
+++ b/tests/test_run_release.py
@@ -8,6 +8,7 @@ import run_release
     [
         ("github.com/hugovk/cpython.git", "hugovk"),
         ("git@github.com:hugovk/cpython.git", "hugovk"),
+        ("https://github.com/hugovk/cpython.git", "hugovk"),
     ],
 )
 def test_extract_github_owner(url: str, expected: str) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ env_list =
 skip_install = true
 deps =
     -r dev-requirements.txt
+    -r requirements.txt
 commands =
     {envpython} -m pytest \
       tests/ \


### PR DESCRIPTION
First, refactor the code into its own function, so it can be easily unit tested, and add tests for existing functionality:

* the `git@github.com:hugovk/cpython.git` form looks good for an SSH remote
* but is `github.com/hugovk/cpython.git` (without `https://`) okay for HTTPS?

Second, fix the error I get below:

```pytb
✅  Create tag
✅  Push new tags and branches to private fork
💥  Start the builds for source and docs artifacts
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1235, in <module>
    main()
  File "/Users/hugo/github/release-tools/run_release.py", line 1231, in main
    automata.run()
  File "/Users/hugo/github/release-tools/run_release.py", line 254, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 251, in run
    self.current_task(self.db)
  File "/Users/hugo/github/release-tools/run_release.py", line 189, in __call__
    return getattr(self, "function")(db)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 769, in start_build_of_source_and_docs
    raise ReleaseException(
ReleaseException: Could not parse GitHub owner from 'origin' remote URL: https://github.com/hugovk/cpython.git
```

My clone has an origin like `https://github.com/hugovk/cpython.git`, which is what I get with GitHub HTTPS or GitHub CLI clones.

So allow an `https://` prefix for HTTPS remotes.
