### PR TITLE
Add tests and type hints for `add_to_pydotorg`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,5 +4,5 @@
 # Regexes for lines to exclude from consideration
 exclude_also =
     # Don't complain if non-runnable code isn't run:
-    if __name__ == .__main__.:
+    if __name__ == .__main__.
     def main

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 #
 .idea/
-venv/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -157,12 +157,6 @@ def get_file_descriptions(release):
     ]
 
 
-def changelog_for(release):
-    new_url = f"http://docs.python.org/release/{release}/whatsnew/changelog.html"
-    if requests.head(new_url).status_code != 200:
-        return f"http://hg.python.org/cpython/file/v{release}/Misc/NEWS"
-
-
 def slug_for(release):
     return base_version(release).replace(".", "") + (
         "-" + release[len(base_version(release)) :]

--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -15,7 +15,7 @@ To use (RELEASE is something like 3.3.5rc2):
 
 * Put an AUTH_INFO variable containing "username:api_key" in your environment.
 
-* Call this script as "python add-to-pydotorg.py RELEASE".
+* Call this script as "python add_to_pydotorg.py RELEASE".
 
   Each call will remove all previous file objects, so you can call the script
   multiple times.

--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -195,7 +195,7 @@ def minor_version(release):
 
 def minor_version_tuple(release):
     m = tag_cre.match(release)
-    return (int(m.groups()[0]), int(m.groups()[1]))
+    return int(m.groups()[0]), int(m.groups()[1])
 
 
 def build_file_dict(release, rfile, rel_pk, file_desc, os_pk, add_download, add_desc):

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -3,3 +3,4 @@ mypy==1.10
 pytest
 pytest-mock
 sigstore==1.1.2
+types-requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ extra_checks = true
 warn_unreachable = true
 
 exclude = [
-  "^add-to-pydotorg.py$",
+  "^add_to_pydotorg.py$",
   "^buildbotapi.py$",
   "^run_release.py$",
   "^sbom.py$",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ extra_checks = true
 warn_unreachable = true
 
 exclude = [
-  "^add_to_pydotorg.py$",
   "^buildbotapi.py$",
   "^run_release.py$",
   "^sbom.py$",

--- a/run_release.py
+++ b/run_release.py
@@ -524,8 +524,8 @@ def sign_source_artifacts(db: DbfilenameShelf) -> None:
         uid = input("Please enter key ID to use for signing: ")
 
     tarballs_path = pathlib.Path(db["git_repo"] / str(db["release"]) / "src")
-    tgz = str(tarballs_path / (f"Python-{db['release']}.tgz"))
-    xz = str(tarballs_path / (f"Python-{db['release']}.tar.xz"))
+    tgz = str(tarballs_path / f"Python-{db['release']}.tgz")
+    xz = str(tarballs_path / f"Python-{db['release']}.tar.xz")
 
     subprocess.check_call(["gpg", "-bas", "-u", uid, tgz])
     subprocess.check_call(["gpg", "-bas", "-u", uid, xz])

--- a/run_release.py
+++ b/run_release.py
@@ -867,8 +867,8 @@ def run_add_to_python_dot_org(db: DbfilenameShelf) -> None:
     client.connect(DOWNLOADS_SERVER, port=22, username=db["ssh_user"])
 
     # Ensure the file is there
-    source = pathlib.Path(__file__).parent / "add-to-pydotorg.py"
-    destination = pathlib.Path(f"/home/psf-users/{db['ssh_user']}/add-to-pydotorg.py")
+    source = pathlib.Path(__file__).parent / "add_to_pydotorg.py"
+    destination = pathlib.Path(f"/home/psf-users/{db['ssh_user']}/add_to_pydotorg.py")
     ftp_client = MySFTPClient.from_transport(client.get_transport())
     ftp_client.put(str(source), str(destination))
     ftp_client.close()
@@ -881,7 +881,7 @@ def run_add_to_python_dot_org(db: DbfilenameShelf) -> None:
     identity_token = issuer.identity_token()
 
     stdin, stdout, stderr = client.exec_command(
-        f"AUTH_INFO={auth_info} SIGSTORE_IDENTITY_TOKEN={identity_token} python3 add-to-pydotorg.py {db['release']}"
+        f"AUTH_INFO={auth_info} SIGSTORE_IDENTITY_TOKEN={identity_token} python3 add_to_pydotorg.py {db['release']}"
     )
     stderr_text = stderr.read().decode()
     if stderr_text:

--- a/run_release.py
+++ b/run_release.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import builtins
 import contextlib
 import functools
 import getpass
@@ -24,7 +23,7 @@ import time
 import urllib.request
 from dataclasses import dataclass
 from shelve import DbfilenameShelf
-from typing import Any, Callable, Generator, Iterator
+from typing import Any, Callable, Iterator
 
 import aiohttp
 import gnupg
@@ -280,14 +279,6 @@ def cd(path: str) -> Iterator[None]:
     os.chdir(path)
     yield
     os.chdir(current_path)
-
-
-@contextlib.contextmanager
-def supress_print() -> Generator[None, None, None]:
-    print_func = builtins.print
-    builtins.print = lambda *args, **kwargs: None
-    yield
-    builtins.print = print_func
 
 
 def check_tool(db: DbfilenameShelf, tool: str) -> None:

--- a/tests/test_add_to_pydotorg.py
+++ b/tests/test_add_to_pydotorg.py
@@ -1,0 +1,81 @@
+import os
+
+import pytest
+
+os.environ["AUTH_INFO"] = "test_username:test_api_key"
+
+import add_to_pydotorg  # noqa: E402
+
+RELEASE = "3.14.0a0"
+
+
+@pytest.mark.parametrize(
+    ["release", "expected"],
+    [
+        ("3.9.0a0", "390-a0"),
+        ("3.10.0b3", "3100-b3"),
+        ("3.11.0rc2", "3110-rc2"),
+        ("3.12.15", "31215"),
+    ],
+)
+def test_slug_for(release: str, expected: str) -> None:
+    assert add_to_pydotorg.slug_for(release) == expected
+
+
+def test_sigfile_for() -> None:
+    assert (
+        add_to_pydotorg.sigfile_for("3.14.0", "Python-3.13.0.tgz")
+        == "https://www.python.org/ftp/python/3.14.0/Python-3.13.0.tgz.asc"
+    )
+
+
+@pytest.mark.parametrize(
+    ["release", "expected"],
+    [
+        ("3.9.0a0", "390a0"),
+        ("3.10.0b3", "3100b3"),
+        ("3.11.0rc2", "3110rc2"),
+        ("3.12.15", "31215"),
+    ],
+)
+def test_make_slug(release: str, expected: str) -> None:
+    assert add_to_pydotorg.make_slug(release) == expected
+
+
+@pytest.mark.parametrize(
+    ["release", "expected"],
+    [
+        ("3.9.0a0", "3.9.0"),
+        ("3.10.0b3", "3.10.0"),
+        ("3.11.0rc2", "3.11.0"),
+        ("3.12.15", "3.12.15"),
+    ],
+)
+def test_base_version(release: str, expected: str) -> None:
+    assert add_to_pydotorg.base_version(release) == expected
+
+
+@pytest.mark.parametrize(
+    ["release", "expected"],
+    [
+        ("3.9.0a0", "3.9"),
+        ("3.10.0b3", "3.10"),
+        ("3.11.0rc2", "3.11"),
+        ("3.12.15", "3.12"),
+    ],
+)
+def test_minor_version(release: str, expected: str) -> None:
+    assert add_to_pydotorg.minor_version(release) == expected
+
+
+@pytest.mark.parametrize(
+    ["release", "expected"],
+    [
+        ("3.9.0a0", (3, 9)),
+        ("3.10.0b3", (3, 10)),
+        ("3.11.0rc2", (3, 11)),
+        ("3.12.15", (3, 12)),
+    ],
+)
+def test_minor_version_tuple(release: str, expected: tuple[int, int]) -> None:
+    assert add_to_pydotorg.minor_version_tuple(release) == expected


### PR DESCRIPTION
Plus rename with underscores to make testable, and remove some unused functions.

Helps https://github.com/python/release-tools/issues/114.

TODO: After merge, rename as `add_to_pydotorg.py` in PEP 101.