### PR TITLE
Remove space from '32 -bit'

### DIFF
--- a/add-to-pydotorg.py
+++ b/add-to-pydotorg.py
@@ -116,7 +116,7 @@ def get_file_descriptions(release):
             rx(r"-embed-win32\.zip$"),
             ("Windows embeddable package (32-bit)", 1, False, ""),
         ),
-        (rx(r"\.exe$"), ("Windows installer (32 -bit)", 1, v < (3, 9), "")),
+        (rx(r"\.exe$"), ("Windows installer (32-bit)", 1, v < (3, 9), "")),
         (rx(r"\.chm$"), ("Windows help file", 1, False, "")),
         (
             rx(r"-macosx10\.5(_rev\d)?\.(dm|pk)g$"),


### PR DESCRIPTION
Re: https://discuss.python.org/t/why-is-there-an-extra-space-in-download-windows-installer-32-bit/46589.

Since https://github.com/python/release-tools/commit/819af73e38603262ae80b718535a6fabfa35386f, there's been a rogue space in "Windows installer (32 -bit)" on download pages, for example:

https://www.python.org/downloads/release/python-3124/

This will fix future uploads. Ee can then do a query to fix old ones.