### PR TITLE
Remove unused CHM handling

### DIFF
--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -122,7 +122,6 @@ def get_file_descriptions(
             ("Windows embeddable package (32-bit)", 1, False, ""),
         ),
         (rx(r"\.exe$"), ("Windows installer (32-bit)", 1, v < (3, 9), "")),
-        (rx(r"\.chm$"), ("Windows help file", 1, False, "")),
         (
             rx(r"-macosx10\.5(_rev\d)?\.(dm|pk)g$"),
             (
@@ -259,26 +258,26 @@ def list_files(release: str) -> Generator[tuple[str, str, int, bool, str], None,
     for rfile in os.listdir(path.join(ftp_root, reldir)):
         if not path.isfile(path.join(ftp_root, reldir, rfile)):
             continue
+
         if rfile.endswith((".asc", ".sig", ".crt", ".sigstore", ".spdx.json")):
             continue
+
         for prefix in ("python", "Python"):
             if rfile.startswith(prefix):
                 break
         else:
             print(f"    File {reldir}/{rfile} has wrong prefix")
             continue
-        if rfile.endswith(".chm"):
-            if rfile[:-4] != "python" + release.replace(".", ""):
-                print(f"    File {reldir}/{rfile} has a different version")
-                continue
-        else:
-            try:
-                prefix, rest = rfile.split("-", 1)
-            except:  # noqa: E722
-                prefix, rest = rfile, ""
-            if not rest.startswith((release + "-", release + ".")):
-                print(f"    File {reldir}/{rfile} has a different version")
-                continue
+
+        try:
+            prefix, rest = rfile.split("-", 1)
+        except:  # noqa: E722
+            prefix, rest = rfile, ""
+
+        if not rest.startswith((release + "-", release + ".")):
+            print(f"    File {reldir}/{rfile} has a different version")
+            continue
+
         for rx, info in get_file_descriptions(release):
             if rx.search(rfile):
                 file_desc, os_pk, add_download, add_desc = info

--- a/size.py
+++ b/size.py
@@ -13,7 +13,7 @@ DOT = "."
 sort_order = {
     ext: i
     for i, ext in enumerate(
-        ("tgz", "tar.bz2", "tar.xz", "pdb.zip", "amd64.msi", "msi", "chm", "dmg")
+        ("tgz", "tar.bz2", "tar.xz", "pdb.zip", "amd64.msi", "msi", "dmg")
     )
 }
 

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -12,7 +12,6 @@ import size
         ("file.pdb.zip", False),
         ("file.amd64.msi", False),
         ("file.msi", False),
-        ("file.chm", False),
         ("file.dmg", False),
         ("file.ext", True),
     ],
@@ -30,8 +29,7 @@ def test_ignore(filename: str, expected: bool) -> None:
         ("file.pdb.zip", 3),
         ("file.amd64.msi", 4),
         ("file.msi", 5),
-        ("file.chm", 6),
-        ("file.dmg", 7),
+        ("file.dmg", 6),
         ("file.ext", 9999),
     ],
 )

--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -63,10 +63,6 @@ parameters:
   displayName: "Run ARM64 PGO (requires custom VM)"
   type: boolean
   default: true
-- name: DoCHM
-  displayName: "Produce compiled help document (pre-3.11)"
-  type: boolean
-  default: false
 - name: DoLayout
   displayName: "Produce full layout artifact"
   type: boolean
@@ -109,7 +105,6 @@ variables:
     IsRealSigned: true
   ${{ else }}:
     IsRealSigned: false
-  DoCHM: ${{ parameters.DoCHM }}
   DoFreethreaded: ${{ parameters.DoFreethreaded }}
   DoLayout: ${{ parameters.DoLayout }}
   DoMSIX: ${{ parameters.DoMSIX }}

--- a/windows-release/stage-build.yml
+++ b/windows-release/stage-build.yml
@@ -22,12 +22,6 @@ jobs:
     env:
       BUILDDIR: $(Build.BinariesDirectory)\Doc
 
-  - script: Doc\make.bat htmlhelp
-    displayName: 'Build CHM docs'
-    condition: and(succeeded(), eq(variables['DoCHM'], 'true'))
-    env:
-      BUILDDIR: $(Build.BinariesDirectory)\Doc
-
   - task: CopyFiles@2
     displayName: 'Assemble artifact: Doc'
     inputs:
@@ -35,7 +29,6 @@ jobs:
       targetFolder: $(Build.ArtifactStagingDirectory)\Doc
       contents: |
         html\**\*
-        htmlhelp\*.chm
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish artifact: doc'

--- a/windows-release/stage-publish-pythonorg.yml
+++ b/windows-release/stage-publish-pythonorg.yml
@@ -112,9 +112,6 @@ jobs:
       git clone https://github.com/python/cpython-bin-deps --branch gpg --single-branch --depth 1 --progress -v "gpg"
       gpg/gpg2.exe --import "$(gpgkey.secureFilePath)"
       $files = gci -File "msi\*\*", "embed\*.zip"
-      if ("$(DoCHM)" -ieq "true") {
-          $files = $files + (gci -File "doc\htmlhelp\*.chm")
-      }
       $files.FullName | %{
           gpg/gpg2.exe -ba --batch --passphrase $(GPGPassphrase) $_
           "Made signature for $_"
@@ -148,7 +145,6 @@ jobs:
       -server $(PyDotOrgServer)
       -hostkey $(PyDotOrgHostKey)
       -keyfile "$(sshkey.secureFilePath)"
-      -doc_htmlhelp doc\htmlhelp
       -embed embed
       -sbom sbom
     workingDirectory: $(Build.BinariesDirectory)
@@ -187,9 +183,6 @@ jobs:
   - ${{ each alg in parameters.HashAlgorithms }}:
     - powershell: |
         $files = gci -File "msi\*\*.exe", "embed\*.zip"
-        if ("$(DoCHM)" -ieq "true") {
-            $files = $files + (gci -File "doc\htmlhelp\python*.chm")
-        }
         $hashes = $files  | `
             Sort-Object Name | `
             Format-Table Name, @{
@@ -206,9 +199,6 @@ jobs:
   - powershell: |
       "Copying:"
       $files = gci -File "msi\*\python*.asc", "embed\*.asc"
-      if ("$(DoCHM)" -ieq "true") {
-          $files = $files + (gci -File "doc\htmlhelp\*.asc")
-      }
       $files.FullName
       $d = mkdir "$(Build.ArtifactStagingDirectory)\hashes" -Force
       move $files $d -Force

--- a/windows-release/uploadrelease.ps1
+++ b/windows-release/uploadrelease.ps1
@@ -15,8 +15,6 @@
     The subdirectory on the host to copy files to.
 .Parameter tests
     The path to run download tests in.
-.Parameter doc_htmlhelp
-    Optional path besides -build to locate CHM files.
 .Parameter embed
     Optional path besides -build to locate ZIP files.
 #>
@@ -28,7 +26,6 @@ param(
     [Parameter(Mandatory=$true)][string]$keyfile,
     [string]$target="/srv/www.python.org/ftp/python",
     [string]$tests=${env:TEMP},
-    [string]$doc_htmlhelp=$null,
     [string]$embed=$null,
     [string]$sbom=$null
 )
@@ -69,20 +66,10 @@ $plink = find-putty-tool "plink"
 "Upload using $pscp and $plink"
 ""
 
-if ($doc_htmlhelp) {
-    $chm = gci -EA 0 $doc_htmlhelp\python*.chm, $doc_htmlhelp\python*.chm.asc
-} else {
-    $chm = gci -EA 0 $build\python*.chm, $build\python*.chm.asc
-}
-
 $d = "$target/$($p[0])/"
 & $plink -batch -hostkey $hostkey -noagent -i $keyfile "$user@$server" mkdir $d
 & $plink -batch -hostkey $hostkey -noagent -i $keyfile "$user@$server" chgrp downloads $d
 & $plink -batch -hostkey $hostkey -noagent -i $keyfile "$user@$server" chmod "a+rx" $d
-if ($chm) {
-    & $pscp -batch -hostkey $hostkey -noagent -i $keyfile $chm.FullName "$user@${server}:$d"
-    if (-not $?) { throw "Failed to upload $chm" }
-}
 
 $dirs = gci "$build" -Directory
 if ($embed) {


### PR DESCRIPTION
We stopped distributing ``.chm`` (Windows HTML help) files in Python 3.11, see https://github.com/python/cpython/issues/91242.

And Python 3.8-3.11 are in security mode, meaning only the source is released, no CHM files.

For example:

* https://www.python.org/downloads/release/python-3124/ - 3.12: installers but no CHM
* https://www.python.org/downloads/release/python-3819/ - 3.8: source only and no CHM

We can now remove some redundant CHM code.