### PR TITLE
Add `--no-gpg` to skip signing with GPG

### DIFF
--- a/release.py
+++ b/release.py
@@ -580,7 +580,7 @@ def upload(tag: Tag, username: str) -> None:
         )
 
 
-def make_tag(tag: Tag) -> bool:
+def make_tag(tag: Tag, *, sign_gpg: bool = True) -> bool:
     # make sure we've run blurb export
     good_files = glob.glob("Misc/NEWS.d/" + str(tag) + ".rst")
     bad_files = list(glob.glob("Misc/NEWS.d/next/*/0*.rst"))
@@ -608,13 +608,21 @@ def make_tag(tag: Tag) -> bool:
             ):
                 print("Aborting.")
                 return False
-    print("Signing tag")
-    uid = os.environ.get("GPG_KEY_FOR_RELEASE")
-    if not uid:
-        print("List of available private keys:")
-        run_cmd(['gpg -K | grep -A 1 "^sec"'], shell=True)
-        uid = input("Please enter key ID to use for signing: ")
-    run_cmd(["git", "tag", "-s", "-u", uid, tag.gitname, "-m", "Python " + str(tag)])
+
+    if sign_gpg:
+        print("Signing tag")
+        uid = os.environ.get("GPG_KEY_FOR_RELEASE")
+        if not uid:
+            print("List of available private keys:")
+            run_cmd(['gpg -K | grep -A 1 "^sec"'], shell=True)
+            uid = input("Please enter key ID to use for signing: ")
+        run_cmd(
+            ["git", "tag", "-s", "-u", uid, tag.gitname, "-m", "Python " + str(tag)]
+        )
+    else:
+        print("Creating tag")
+        run_cmd(["git", "tag", tag.gitname, "-m", "Python " + str(tag)])
+
     return True
 
 

--- a/run_release.py
+++ b/run_release.py
@@ -201,6 +201,7 @@ class ReleaseDriver:
         git_repo: str,
         api_key: str,
         ssh_user: str,
+        sign_gpg: bool,
         first_state: Task | None = None,
     ) -> None:
         self.tasks = tasks
@@ -223,6 +224,8 @@ class ReleaseDriver:
             self.db["auth_info"] = api_key
         if not self.db.get("ssh_user"):
             self.db["ssh_user"] = ssh_user
+        if not self.db.get("sign_gpg"):
+            self.db["sign_gpg"] = sign_gpg
 
         if not self.db.get("release"):
             self.db["release"] = release_tag
@@ -233,7 +236,8 @@ class ReleaseDriver:
         print(f"- Normalized release tag: {release_tag.normalized()}")
         print(f"- Git repo: {self.db['git_repo']}")
         print(f"- SSH username: {self.db['ssh_user']}")
-        print(f"- python.org API key : {self.db['auth_info']}")
+        print(f"- python.org API key: {self.db['auth_info']}")
+        print(f"- Sign with GPG: {self.db['sign_gpg']}")
         print()
 
     def checkpoint(self) -> None:
@@ -465,7 +469,7 @@ def bump_version(db: DbfilenameShelf) -> None:
 
 def create_tag(db: DbfilenameShelf) -> None:
     with cd(db["git_repo"]):
-        if not release_mod.make_tag(db["release"]):
+        if not release_mod.make_tag(db["release"], sign_gpg=db["sign_gpg"]):
             raise ReleaseException("Error when creating tag")
     subprocess.check_call(
         ["git", "commit", "-a", "--amend", "--no-edit"], cwd=db["git_repo"]
@@ -1137,6 +1141,11 @@ def main() -> None:
         help="Username to be used when authenticating via ssh",
         type=str,
     )
+    parser.add_argument(
+        "--no-gpg",
+        action="store_true",
+        help="Skip GPG signing",
+    )
     args = parser.parse_args()
 
     auth_key = args.auth_key or os.getenv("AUTH_INFO")
@@ -1164,7 +1173,7 @@ fix these things in this script so it also supports your platform.
         Task(check_docker, "Checking Docker is available"),
         Task(check_docker_running, "Checking Docker is running"),
         Task(check_autoconf, "Checking autoconf is available"),
-        Task(check_gpg_keys, "Checking GPG keys"),
+        None if args.no_gpg else Task(check_gpg_keys, "Checking GPG keys"),
         Task(
             check_ssh_connection,
             f"Validating ssh connection to {DOWNLOADS_SERVER} and {DOCS_SERVER}",
@@ -1196,7 +1205,7 @@ fix these things in this script so it also supports your platform.
             "Wait for source and docs artifacts to build",
         ),
         Task(build_sbom_artifacts, "Building SBOM artifacts"),
-        Task(sign_source_artifacts, "Sign source artifacts"),
+        None if args.no_gpg else Task(sign_source_artifacts, "Sign source artifacts"),
         Task(upload_files_to_server, "Upload files to the PSF server"),
         Task(place_files_in_download_folder, "Place files in the download folder"),
         Task(upload_docs_to_the_docs_server, "Upload docs to the PSF docs server"),
@@ -1216,11 +1225,14 @@ fix these things in this script so it also supports your platform.
         Task(purge_the_cdn, "Purge the CDN of python.org/downloads"),
         Task(modify_the_release_to_the_prerelease_pages, "Modify the pre-release page"),
     ]
+    # Remove any skipped tasks
+    tasks = [task for task in tasks if task]
     automata = ReleaseDriver(
         git_repo=args.repo,
         release_tag=release_mod.Tag(args.release),
         api_key=auth_key,
         ssh_user=args.ssh_user,
+        sign_gpg=not args.no_gpg,
         tasks=tasks,
     )
     automata.run()

--- a/run_release.py
+++ b/run_release.py
@@ -814,7 +814,7 @@ def create_release_object_in_db(db: DbfilenameShelf) -> None:
         "Go to https://www.python.org/admin/downloads/release/add/ and create a new release"
     )
     if not ask_question(f"Have you already created a new release for {db['release']}"):
-        raise ReleaseException("The django release object has not been created")
+        raise ReleaseException("The Django release object has not been created")
 
 
 def wait_until_all_files_are_in_folder(db: DbfilenameShelf) -> None:
@@ -1211,7 +1211,7 @@ fix these things in this script so it also supports your platform.
         Task(upload_docs_to_the_docs_server, "Upload docs to the PSF docs server"),
         Task(unpack_docs_in_the_docs_server, "Place docs files in the docs folder"),
         Task(wait_until_all_files_are_in_folder, "Wait until all files are ready"),
-        Task(create_release_object_in_db, "The django release object has been created"),
+        Task(create_release_object_in_db, "The Django release object has been created"),
         Task(post_release_merge, "Merge the tag into the release branch"),
         Task(branch_new_versions, "Branch out new versions and prepare main branch"),
         Task(post_release_tagging, "Final touches for the release"),


### PR DESCRIPTION
@sethmlarson and I are planning on replacing GPG signing with Sigstore for 3.14.

Here's a first step to update the tooling for this, adding a `--no-gpg` flag to skip signing with GPG. By default, GPG signing is still used, per the the status quo.

(Also fix a "django"->"Django" typo.)
