### PR TITLE
Upgrade Requests to 2.32.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -667,9 +667,8 @@ python-gnupg==0.5.1 \
     --hash=sha256:5674bad4e93876c0b0d3197e314d7f942d39018bf31e2b833f6788a6813c3fb8 \
     --hash=sha256:bf9b2d9032ef38139b7d64184176cd0b293eaeae6e4f93f50e304c7051174482
     # via -r requirements.in
-requests==2.32.0 \
-    --hash=sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5 \
-    --hash=sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8
+requests==2.32.3 \
+    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
     #   id
     #   sigstore


### PR DESCRIPTION
2.32.0 is yanked due to an issue w/ a security mitigation.