### PR TITLE
Make X more obvious

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -922,9 +922,9 @@ def wait_until_all_files_are_in_folder(db: ReleaseShelf) -> None:
             are_linux_files_there and are_windows_files_there and are_macos_files_there
         )
         if not are_all_files_there:
-            linux_tick = "✅" if are_linux_files_there else "❎"
-            windows_tick = "✅" if are_windows_files_there else "❎"
-            macos_tick = "✅" if are_macos_files_there else "❎"
+            linux_tick = "✅" if are_linux_files_there else "❌"
+            windows_tick = "✅" if are_windows_files_there else "❌"
+            macos_tick = "✅" if are_macos_files_there else "❌"
             print(
                 f"\rWaiting for files: Linux {linux_tick} Windows {windows_tick} Mac {macos_tick}",
                 flush=True,


### PR DESCRIPTION
Instead of:

```
✅  Upload files to the PSF server
✅  Place files in the download folder
✅  Upload docs to the PSF docs server
✅  Place docs files in the docs folder

Waiting for files: Linux ✅ Windows ❎ Mac ❎
```

Show this:

```
✅  Upload files to the PSF server
✅  Place files in the download folder
✅  Upload docs to the PSF docs server
✅  Place docs files in the docs folder

Waiting for files: Linux ✅ Windows ❌ Mac ❌
```