### PR TITLE
Create `src` and `docs` dirs

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -521,15 +521,17 @@ def wait_for_source_and_docs_artifacts(db: ReleaseShelf) -> None:
 
     # Create the directory so it's easier to place the artifacts there.
     release_path = Path(db["git_repo"] / str(release_tag))
-    release_path.mkdir(parents=True, exist_ok=True)
+    src_path = release_path / "src"
+    src_path.mkdir(parents=True, exist_ok=True)
 
     # Build the list of filepaths we're expecting.
     wait_for_paths = [
-        release_path / "src" / f"Python-{release_tag}.tgz",
-        release_path / "src" / f"Python-{release_tag}.tar.xz",
+        src_path / f"Python-{release_tag}.tgz",
+        src_path / f"Python-{release_tag}.tar.xz",
     ]
     if should_wait_for_docs:
         docs_path = release_path / "docs"
+        docs_path.mkdir(parents=True, exist_ok=True)
         wait_for_paths.extend(
             [
                 docs_path / f"python-{release_tag}-docs.epub",


### PR DESCRIPTION
Part of the release process:

```
Waiting for source artifacts to be built
Artifacts should be placed at '../cpython/3.14.0a1':
- 'src/Python-3.14.0a1.tgz'
- 'src/Python-3.14.0a1.tar.xz'
```
The `../cpython/3.14.0a1` directory had already been created by the script, but I had to create `src` myself before copying over the files from the CI.

Let's create the `src` directory in the script, and when needed, the `docs` directory.
