### PR TITLE
Make venv before pydoc topics

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -432,6 +432,7 @@ def remove_temporary_branch(db: ReleaseShelf) -> None:
 
 
 def prepare_pydoc_topics(db: ReleaseShelf) -> None:
+    subprocess.check_call(["make", "venv"], cwd=db["git_repo"] / "Doc")
     subprocess.check_call(["make", "pydoc-topics"], cwd=db["git_repo"] / "Doc")
     shutil.copy2(
         db["git_repo"] / "Doc" / "build" / "pydoc-topics" / "topics.py",


### PR DESCRIPTION
During practice runs, I must have already had the venv under `Docs/` in my CPython repo.

Before yesterday's release, I did a `git clean -fdx .`, and then hit this during the release:


```pytb
✅  Run blurb release
✅  Checking Git repository is clean
mkdir -p build

Missing the required blurb or sphinx-build tools.
Please run 'make venv' to install local copies.

make: *** [build] Error 1
💥  Preparing pydoc topics
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1339, in <module>
    main()
  File "/Users/hugo/github/release-tools/run_release.py", line 1335, in main
    automata.run()
  File "/Users/hugo/github/release-tools/run_release.py", line 245, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 242, in run
    self.current_task(self.db)
  File "/Users/hugo/github/release-tools/release.py", line 126, in __call__
    return getattr(self, "function")(db)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 435, in prepare_pydoc_topics
    subprocess.check_call(["make", "pydoc-topics"], cwd=db["git_repo"] / "Doc")
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['make', 'pydoc-topics']' returned non-zero exit status 2.
```

The fix is to run the equivalent of `make -C Doc venv` before `make -C Doc pydoc-topics`.

After:

```
✅  Run blurb release
✅  Checking Git repository is clean
Creating venv in ./venv
Using CPython 3.12.5
Creating virtual environment at: ./venv
Activate with: source venv/bin/activate
Using Python 3.12.5 environment at venv
Resolved 25 packages in 180ms
Installed 25 packages in 111ms
 + alabaster==1.0.0
 + babel==2.16.0
 + blurb==1.2.1
 + certifi==2024.8.30
 + charset-normalizer==3.4.0
 + docutils==0.21.2
 + idna==3.10
 + imagesize==1.4.1
 + jinja2==3.1.4
 + markupsafe==2.1.5
 + packaging==24.1
 + pygments==2.18.0
 + python-docs-theme==2024.6
 + requests==2.32.3
 + snowballstemmer==2.2.0
 + sphinx==8.1.3
 + sphinx-notfound-page==1.0.4
 + sphinxcontrib-applehelp==2.0.0
 + sphinxcontrib-devhelp==2.0.0
 + sphinxcontrib-htmlhelp==2.1.0
 + sphinxcontrib-jsmath==1.0.1
 + sphinxcontrib-qthelp==2.0.0
 + sphinxcontrib-serializinghtml==2.0.0
 + sphinxext-opengraph==0.9.1
 + urllib3==2.2.3
The venv has been created in the ./venv directory
mkdir -p build
Building NEWS from Misc/NEWS.d with blurb
PATH=./venv/bin:$PATH sphinx-build -b pydoc-topics -d build/doctrees -j auto   -W . build/pydoc-topics
Running Sphinx v8.1.3
...
```
