### PR TITLE
Fix for macOS: tar: Option --to-command=... is not supported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,18 @@ env:
 jobs:
   tests:
     name: "Tests"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: 3.x
+          python-version: 3.12
           cache: pip
           cache-dependency-path: dev-requirements.txt
       - run: |


### PR DESCRIPTION
Opening as a bug report, also happens when running `tox -e py312` locally on macOS:

```pytb
=================================== FAILURES ===================================
_____________________ test_check_doc_unreleased_version_ok _____________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1061f9d30>
tmp_path = PosixPath('/private/var/folders/g6/rgtlsw6n123b0gt5483s5_cm0000gn/T/pytest-of-runner/pytest-0/test_check_doc_unreleased_vers2')

    def test_check_doc_unreleased_version_ok(monkeypatch, tmp_path: Path) -> None:
        prepare_fake_docs(
            tmp_path,
            "<div>New in 3.13</div>",
        )
        db = {
            "release": Tag("3.13.0rc1"),
            "git_repo": str(tmp_path),
        }
>       run_release.check_doc_unreleased_version(cast(ReleaseShelf, db))

tests/test_run_release.py:100: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
run_release.py:582: in check_doc_unreleased_version
    if not ask_question("Are these `(unreleased)` strings in built docs OK?"):
run_release.py:258: in ask_question
    answer = input("Enter yes or no: ")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_pytest.capture.DontReadFromInput object at 0x103ce[45](https://github.com/hugovk/release-tools/actions/runs/11601299635/job/32303698930#step:5:46)60>, size = -1

    def read(self, size: int = -1) -> str:
>       raise OSError(
            "pytest: reading from stdin while output is captured!  Consider using `-s`."
        )
E       OSError: pytest: reading from stdin while output is captured!  Consider using `-s`.

.tox/py/lib/python3.12/site-packages/_pytest/capture.py:205: OSError
----------------------------- Captured stdout call -----------------------------
Checking built docs for '(unreleased)'
Are these `(unreleased)` strings in built docs OK?
Enter yes or no: 
----------------------------- Captured stderr call -----------------------------
tar: Option --to-command=! grep -Hn --label="$TAR_FILENAME" "[(]unreleased[)]" is not supported
Usage:
  List:    tar -tf <archive-filename>
  Extract: tar -xf <archive-filename>
  Create:  tar -cf <archive-filename> [filenames...]
  Help:    tar --help
```

```console
❯ which tar
/usr/bin/tar
❯ tar --version
bsdtar 3.5.3 - libarchive 3.5.3 zlib/1.2.12 liblzma/5.4.3 bz2lib/1.0.8
```

https://man.freebsd.org/cgi/man.cgi?bsdtar(1) has no mention of `--to-command`.

However, GNU tar does have `--to-command`, which is presumably the GNU/Linux one:

https://www.gnu.org/software/tar/manual/html_node/Writing-to-an-External-Program.html

This was added in https://github.com/python/release-tools/pull/164, cc @encukou.

