### PR TITLE
PEP 761: Python 3.14+ discontinues PGP signatures

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -1264,7 +1264,8 @@ fix these things in this script so it also supports your platform.
                 "This release script is not compatible with the running platform"
             )
 
-    no_gpg = args.no_gpg
+    release_tag = release_mod.Tag(args.release)
+    no_gpg = args.no_gpg or release_tag.as_tuple() >= (3, 14)
     tasks = [
         Task(check_git, "Checking Git is available"),
         Task(check_make, "Checking make is available"),
@@ -1329,10 +1330,10 @@ fix these things in this script so it also supports your platform.
     ]
     automata = ReleaseDriver(
         git_repo=args.repo,
-        release_tag=release_mod.Tag(args.release),
+        release_tag=release_tag,
         api_key=auth_key,
         ssh_user=args.ssh_user,
-        sign_gpg=not args.no_gpg,
+        sign_gpg=not no_gpg,
         tasks=tasks,
     )
     automata.run()

--- a/run_release.py
+++ b/run_release.py
@@ -1260,7 +1260,7 @@ fix these things in this script so it also supports your platform.
             )
 
     release_tag = release_mod.Tag(args.release)
-    no_gpg = release_tag.as_tuple() >= (3, 14)
+    no_gpg = release_tag.as_tuple() >= (3, 14)  # see PEP 761
     tasks = [
         Task(check_git, "Checking Git is available"),
         Task(check_make, "Checking make is available"),

--- a/run_release.py
+++ b/run_release.py
@@ -1239,11 +1239,6 @@ def main() -> None:
         help="Username to be used when authenticating via ssh",
         type=str,
     )
-    parser.add_argument(
-        "--no-gpg",
-        action="store_true",
-        help="Skip GPG signing",
-    )
     args = parser.parse_args()
 
     auth_key = args.auth_key or os.getenv("AUTH_INFO")
@@ -1265,7 +1260,7 @@ fix these things in this script so it also supports your platform.
             )
 
     release_tag = release_mod.Tag(args.release)
-    no_gpg = args.no_gpg or release_tag.as_tuple() >= (3, 14)
+    no_gpg = release_tag.as_tuple() >= (3, 14)
     tasks = [
         Task(check_git, "Checking Git is available"),
         Task(check_make, "Checking make is available"),


### PR DESCRIPTION
[PEP 761](https://peps.python.org/pep-0761/) has been accepted:

* https://discuss.python.org/t/pep-761-deprecating-pgp-signatures-for-cpython-artifacts/67180/39
* https://github.com/python/steering-council/issues/260

This PEP automatically skips PGP signatures for 3.14+.

It also removes the `--no-gpg` flag because 3.13 and older will still be PGP signed.

cc @sethmlarson 