### PR TITLE
Switch to new signing tool for Windows releases

### DIFF
--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -165,9 +165,8 @@ stages:
     jobs:
     - template: stage-pack-nuget.yml
       parameters:
-        # Nuget signing is disabled because Azure Trusted Signing does not support it
-        #${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
-        #  SigningCertificate: ${{ parameters.SigningCertificate }}
+        ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
+          SigningCertificate: ${{ parameters.SigningCertificate }}
         DoFreethreaded: ${{ parameters.DoFreethreaded }}
 
   - stage: Test

--- a/windows-release/sign-files.yml
+++ b/windows-release/sign-files.yml
@@ -37,11 +37,13 @@ steps:
         }
         if ($env:FILTER) {
           ($env:FILTER -split ';') -join "`n" | Out-File __filelist.txt -Encoding utf8
-          $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $_ }
+          $ec = $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $_; $LASTEXITCODE }
           del __filelist.txt
         } else {
-          $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) $_ }
+          $ec = $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) $_; $LASTEXITCODE }
         }
+        # Ensure we correctly fail the task if any signature failed
+        $ec | ?{ $_ -ne 0 } | %{ exit $_ }
       displayName: 'Sign binaries'
       retryCountOnTaskFailure: 3
       workingDirectory: ${{ parameters.WorkingDir }}

--- a/windows-release/sign-files.yml
+++ b/windows-release/sign-files.yml
@@ -6,6 +6,7 @@ parameters:
   ExtractDir: ''
   SigningCertificate: ''
   ExportCommand: ''
+  ContinueOnError: false
 
 steps:
 - ${{ if parameters.SigningCertificate }}:
@@ -46,7 +47,10 @@ steps:
         }
         del __filelist.txt
       displayName: 'Sign binaries'
-      retryCountOnTaskFailure: 3
+      ${{ if eq(parameters.ContinueOnError, 'false') }}:
+        retryCountOnTaskFailure: 3
+      ${{ else }}:
+        continueOnError: true
       workingDirectory: ${{ parameters.WorkingDir }}
       env:
         TRUSTED_SIGNING_CMD: $(__TrustedSigningCmd)

--- a/windows-release/sign-files.yml
+++ b/windows-release/sign-files.yml
@@ -37,13 +37,14 @@ steps:
         }
         if ($env:FILTER) {
           ($env:FILTER -split ';') -join "`n" | Out-File __filelist.txt -Encoding utf8
-          $ec = $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $_; $LASTEXITCODE }
-          del __filelist.txt
         } else {
-          $ec = $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) $_; $LASTEXITCODE }
+          "*" | Out-File __filelist.txt -Encoding utf8
         }
-        # Ensure we correctly fail the task if any signature failed
-        $ec | ?{ $_ -ne 0 } | %{ exit $_ }
+        foreach ($f in $files) {
+          & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $_
+          if (-not $?) { exit $LASTEXITCODE }
+        }
+        del __filelist.txt
       displayName: 'Sign binaries'
       retryCountOnTaskFailure: 3
       workingDirectory: ${{ parameters.WorkingDir }}

--- a/windows-release/sign-files.yml
+++ b/windows-release/sign-files.yml
@@ -37,10 +37,10 @@ steps:
         }
         if ($env:FILTER) {
           ($env:FILTER -split ';') -join "`n" | Out-File __filelist.txt -Encoding utf8
-          & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $files
+          $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $_ }
           del __filelist.txt
         } else {
-          & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) $files
+          $files | %{ & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) $_ }
         }
       displayName: 'Sign binaries'
       retryCountOnTaskFailure: 3

--- a/windows-release/sign-files.yml
+++ b/windows-release/sign-files.yml
@@ -1,6 +1,7 @@
 parameters:
   Include: '*'
   Exclude: ''
+  Filter: ''
   WorkingDir: '$(Build.BinariesDirectory)'
   ExtractDir: ''
   SigningCertificate: ''
@@ -9,32 +10,13 @@ parameters:
 steps:
 - ${{ if parameters.SigningCertificate }}:
   - powershell: |
-      cd (mkdir -Force _signing)
-      iwr https://aka.ms/nugetclidl -o nuget.exe
-      .\nuget.exe install Microsoft.Windows.SDK.BuildTools -x -o .
-      .\nuget.exe install Microsoft.Trusted.Signing.Client -x -o .
-      $md = @{
-        Endpoint='$(TrustedSigningUri)';
-        CodeSigningAccountName='$(TrustedSigningAccount)';
-        CertificateProfileName='$(TrustedSigningCertificateName)';
-        CorrelationId='$(SigningDescription)';
-        ExcludeEnvironmentCredential=$false;
-        ExcludeManagedIdentityCredential=$true;
-        ExcludeSharedTokenCacheCredential=$true;
-        ExcludeVisualStudioCredential=$true;
-        ExcludeVisualStudioCodeCredential=$true;
-        ExcludeAzureCliCredential=$true;
-        ExcludeAzurePowershellCredential=$true;
-        ExcludeInteractiveBrowserCredential=$true;
-      };
-      # ConvertTo-Json $md | Out-File -Encoding UTF8 .\metadata.json
-      # but without including the BOM...
-      [System.IO.File]::WriteAllText("$(Get-Location)\metadata.json", (ConvertTo-Json $md), [System.Text.UTF8Encoding]::new($false))
+      dotnet tool install --global --prerelease sign
+      $signtool = (gcm sign).Source
+      $signargs = 'code trusted-signing -v Information ' + `
+        '-fd sha256 -t http://timestamp.acs.microsoft.com -td sha256 ' + `
+        '-tse "$(TrustedSigningUri)" -tsa "$(TrustedSigningAccount)" -tscp "$(TrustedSigningCertificateName)" ' + `
+        '-d "$(SigningDescription)" '
 
-      $signtool = dir .\Microsoft.Windows.SDK.BuildTools\*\*\x64\signtool.exe | select -First 1
-      $dlib = dir .\Microsoft.Trusted.Signing.Client\*\x64\Azure.CodeSigning.Dlib.dll | select -First 1
-      $signargs = "sign /v /fd sha256 /tr http://timestamp.acs.microsoft.com /td sha256 " + `
-        "/dlib ""$dlib"" /dmdf ""$(gi metadata.json)"""
       Write-Host "##vso[task.setvariable variable=__TrustedSigningCmd]$signtool"
       Write-Host "##vso[task.setvariable variable=__TrustedSigningArgs]$signargs"
       if ($env:EXPORT_COMMAND) {
@@ -53,7 +35,13 @@ steps:
         } else {
           $files = (dir ${{ parameters.Include }} -File)
         }
-        & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) $files
+        if ($env:FILTER) {
+          ($env:FILTER -split ';') -join "`n" | Out-File __filelist.txt -Encoding utf8
+          & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $files
+          del __filelist.txt
+        } else {
+          & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) $files
+        }
       displayName: 'Sign binaries'
       retryCountOnTaskFailure: 3
       workingDirectory: ${{ parameters.WorkingDir }}
@@ -63,6 +51,8 @@ steps:
         AZURE_TENANT_ID: $(TrustedSigningTenantId)
         AZURE_CLIENT_ID: $(TrustedSigningClientId)
         AZURE_CLIENT_SECRET: $(TrustedSigningSecret)
+        ${{ if parameters.Filter }}:
+          FILTER: ${{ parameters.Filter }}
 
 
 - ${{ if parameters.ExtractDir }}:

--- a/windows-release/sign-files.yml
+++ b/windows-release/sign-files.yml
@@ -41,7 +41,7 @@ steps:
           "*" | Out-File __filelist.txt -Encoding utf8
         }
         foreach ($f in $files) {
-          & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $_
+          & $env:TRUSTED_SIGNING_CMD @(-split $env:TRUSTED_SIGNING_ARGS) -fl __filelist.txt $f
           if (-not $?) { exit $LASTEXITCODE }
         }
         del __filelist.txt

--- a/windows-release/stage-layout-msix.yml
+++ b/windows-release/stage-layout-msix.yml
@@ -69,14 +69,14 @@ jobs:
     env:
       TCL_LIBRARY: $(TclLibrary)
 
-  # HACK: Disabled to test because new signing tool shouldn't need this
-  #- powershell: |
-  #    $info = (gc "$(Pipeline.Workspace)\cert\certinfo.json" | ConvertFrom-JSON)
-  #    Write-Host "Side-loadable APPX must be signed with '$($info.Subject)'"
-  #    Write-Host "##vso[task.setvariable variable=APPX_DATA_PUBLISHER]$($info.Subject)"
-  #    Write-Host "##vso[task.setvariable variable=APPX_DATA_SHA256]$($info.SHA256)"
-  #  displayName: 'Override signing parameters'
-  #  condition: and(succeeded(), variables['SigningCertificate'])
+  # The dotnet sign tool shouldn't need this, but we do because of the sccd file
+  - powershell: |
+      $info = (gc "$(Pipeline.Workspace)\cert\certinfo.json" | ConvertFrom-JSON)
+      Write-Host "Side-loadable APPX must be signed with '$($info.Subject)'"
+      Write-Host "##vso[task.setvariable variable=APPX_DATA_PUBLISHER]$($info.Subject)"
+      Write-Host "##vso[task.setvariable variable=APPX_DATA_SHA256]$($info.SHA256)"
+    displayName: 'Override signing parameters'
+    condition: and(succeeded(), variables['SigningCertificate'])
 
   - powershell: |
       Remove-Item "$(Build.ArtifactStagingDirectory)\appx" -Recurse -Force -EA 0

--- a/windows-release/stage-layout-msix.yml
+++ b/windows-release/stage-layout-msix.yml
@@ -69,13 +69,14 @@ jobs:
     env:
       TCL_LIBRARY: $(TclLibrary)
 
-  - powershell: |
-      $info = (gc "$(Pipeline.Workspace)\cert\certinfo.json" | ConvertFrom-JSON)
-      Write-Host "Side-loadable APPX must be signed with '$($info.Subject)'"
-      Write-Host "##vso[task.setvariable variable=APPX_DATA_PUBLISHER]$($info.Subject)"
-      Write-Host "##vso[task.setvariable variable=APPX_DATA_SHA256]$($info.SHA256)"
-    displayName: 'Override signing parameters'
-    condition: and(succeeded(), variables['SigningCertificate'])
+  # HACK: Disabled to test because new signing tool shouldn't need this
+  #- powershell: |
+  #    $info = (gc "$(Pipeline.Workspace)\cert\certinfo.json" | ConvertFrom-JSON)
+  #    Write-Host "Side-loadable APPX must be signed with '$($info.Subject)'"
+  #    Write-Host "##vso[task.setvariable variable=APPX_DATA_PUBLISHER]$($info.Subject)"
+  #    Write-Host "##vso[task.setvariable variable=APPX_DATA_SHA256]$($info.SHA256)"
+  #  displayName: 'Override signing parameters'
+  #  condition: and(succeeded(), variables['SigningCertificate'])
 
   - powershell: |
       Remove-Item "$(Build.ArtifactStagingDirectory)\appx" -Recurse -Force -EA 0

--- a/windows-release/stage-pack-msix.yml
+++ b/windows-release/stage-pack-msix.yml
@@ -131,6 +131,8 @@ jobs:
     - template: sign-files.yml
       parameters:
         Include: '*.msix'
+        # Additional filter to avoid recursively signing package contents
+        Filter: '*.msix'
         WorkingDir: $(Build.BinariesDirectory)\unsigned_msix
         SigningCertificate: ${{ parameters.SigningCertificate }}
 

--- a/windows-release/stage-pack-nuget.yml
+++ b/windows-release/stage-pack-nuget.yml
@@ -73,6 +73,9 @@ jobs:
       Filter: '*.nupkg'
       WorkingDir: $(Build.ArtifactStagingDirectory)
       SigningCertificate: ${{ parameters.SigningCertificate }}
+      # Nuget signing is not supported by our test certificate, so ignore errors
+      ${{ if eq(parameters.SigningCertificate, 'TestSign') }}:
+        ContinueOnError: true
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: nuget'

--- a/windows-release/stage-pack-nuget.yml
+++ b/windows-release/stage-pack-nuget.yml
@@ -69,6 +69,8 @@ jobs:
   - template: sign-files.yml
     parameters:
       Include: '*.nupkg'
+      # Additional filter to avoid recursively signing package contents
+      Filter: '*.nupkg'
       WorkingDir: $(Build.ArtifactStagingDirectory)
       SigningCertificate: ${{ parameters.SigningCertificate }}
 


### PR DESCRIPTION
The dotnet sign tool is capable of signing all our file types that we need using Trusted Signing, which should simplify our use of it.