### PR TITLE
Make Nuget signing optional (disabled by default)

### DIFF
--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -92,6 +92,10 @@ parameters:
   displayName: "Build number to publish (0 to skip)"
   type: number
   default: '0'
+- name: SignNuget
+  displayName: "Enable Nuget signing (not recommended right now)"
+  type: boolean
+  default: false
 
 variables:
   ${{ if ne(parameters.GitRemote, '(Other)') }}:
@@ -166,7 +170,8 @@ stages:
     - template: stage-pack-nuget.yml
       parameters:
         ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
-          SigningCertificate: ${{ parameters.SigningCertificate }}
+          ${{ if eq(parameters.SignNuget, 'true') }}:
+            SigningCertificate: ${{ parameters.SigningCertificate }}
         DoFreethreaded: ${{ parameters.DoFreethreaded }}
 
   - stage: Test


### PR DESCRIPTION
Nuget will not allow uploading signed packages unless the certificate is registered, and we cannot register Azure Trusted Signing certificates at this time. So it's best to just not sign the package.