### PR TITLE
Remove unused code: `README` is renamed `README.rst` since Python 3.6

### DIFF
--- a/release.py
+++ b/release.py
@@ -248,7 +248,7 @@ def run_cmd(
         error(f"{cmd} failed")
 
 
-readme_re = re.compile(r"This is Python version [23]\.\d").match
+readme_re = re.compile(r"This is Python version 3\.\d").match
 
 
 def chdir_to_repo_root() -> str:
@@ -279,12 +279,8 @@ def chdir_to_repo_root() -> str:
                     return False
             return True
 
-        if not (
-            test_first_line("README", readme_re)
-            or test_first_line("README.rst", readme_re)
-        ):
+        if not test_first_line("README.rst", readme_re):
             continue
-
         if not test_first_line("LICENSE", "A. HISTORY OF THE SOFTWARE".__eq__):
             continue
         if not os.path.exists("Include/Python.h"):


### PR DESCRIPTION
* `README` in https://github.com/python/cpython/tree/3.5
* `README.rst` from https://github.com/python/cpython/tree/3.6 onwards

---

As a followup, it looks like we're only running `release.py` from `./.github/workflows/source-and-docs-release.yml` and only with the `--export` and `--skip-docs` options to build the source artifacts. Docs are built by calling the docs' `make dist` directly.

The release process uses `run_release.py`, so we could remove a bunch of unused code related to the unused `release.py` options: `--bump`, `--upload`, `--branch`, `--tag`, `--done`.

Edit: `--bump`, `--tag`, `--done` are referenced in PEP 101 so should stay.