### PR TITLE
We no longer need to update years in copyright notices

### DIFF
--- a/release.py
+++ b/release.py
@@ -437,8 +437,6 @@ def bump(tag: Tag) -> None:
             "Doc/tutorial/interpreter.rst",
             "Doc/tutorial/stdlib.rst",
             "Doc/tutorial/stdlib2.rst",
-            "LICENSE",
-            "Doc/license.rst",
             "PC/pyconfig.h.in",
             "PCbuild/rt.bat",
             ".github/ISSUE_TEMPLATE/bug.yml",


### PR DESCRIPTION
Re:
* https://devguide.python.org/getting-started/pull-request-lifecycle/#copyrights
* https://github.com/python/cpython/issues/126133#issuecomment-2460824052
* https://github.com/python/cpython/pull/126236
* https://github.com/python/peps/pull/4136

We no longer need to add an new copyright year to `LICENSE` and `Doc/license.rst`.
