### PR TITLE
Add the pip ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    assignees:
+      - "ezio-melotti"
     groups:
       pip:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       actions:
         patterns:
           - "*"
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
I noticed that the `pip` deps are not being updated automatically.
This PR adds the `pip` ecosystem to the `dependabot.yml`.