### PR TITLE
Add zizmor security linter to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.8.2
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
@@ -25,13 +25,13 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.4
+    rev: 0.30.0
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.3
+    rev: v1.7.4
     hooks:
       - id: actionlint
 
@@ -41,12 +41,12 @@ repos:
       - id: zizmor
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.4.3
+    rev: v2.5.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.22
+    rev: v0.23
     hooks:
       - id: validate-pyproject
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.4.3
     hooks:

--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -29,8 +29,9 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Generator
 from os import path
-from typing import Any, Generator, NoReturn
+from typing import Any, NoReturn
 
 import requests
 

--- a/release.py
+++ b/release.py
@@ -19,13 +19,13 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
     Any,
     Callable,
-    Generator,
     Literal,
     Protocol,
     Self,
@@ -524,8 +524,8 @@ def tarball(source: str, clamp_mtime: str) -> None:
     checksum_xz = hashlib.md5()
     with open(xz, "rb") as data:
         checksum_xz.update(data.read())
-    print("  %s  %8s  %s" % (checksum_tgz.hexdigest(), int(os.path.getsize(tgz)), tgz))
-    print("  %s  %8s  %s" % (checksum_xz.hexdigest(), int(os.path.getsize(xz)), xz))
+    print(f"  {checksum_tgz.hexdigest()}  {os.path.getsize(tgz):8}  {tgz}")
+    print(f"  {checksum_xz.hexdigest()}  {os.path.getsize(xz):8}  {xz}")
 
 
 def export(tag: Tag, silent: bool = False, skip_docs: bool = False) -> None:

--- a/run_release.py
+++ b/run_release.py
@@ -21,8 +21,9 @@ import sys
 import tempfile
 import time
 import urllib.request
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Iterator, cast
+from typing import Any, cast
 
 import aiohttp
 import gnupg  # type: ignore[import-untyped]


### PR DESCRIPTION
> `zizmor` is a static analysis tool for GitHub Actions. It can find many common security issues in typical GitHub Actions CI/CD setups.

https://woodruffw.github.io/zizmor/

Seth also recommends avoiding using shared caches in the build and release process:

https://blog.pypi.org/posts/2024-12-11-ultralytics-attack-analysis/

Reviewing the workflows here, we use caches in https://github.com/python/release-tools/blob/master/.github/workflows/test.yml to run unit tests and https://github.com/python/release-tools/blob/master/.github/workflows/lint.yml to lint the code with pre-commit, but importantly don't use any in https://github.com/python/release-tools/blob/master/.github/workflows/source-and-docs-release.yml that creates release artifacts.

I also updated the other pre-commit hooks including new typing and f-string upgrades.