### PR TITLE
Update default Python version for testing PRs

### DIFF
--- a/.github/workflows/source-and-docs-release.yml
+++ b/.github/workflows/source-and-docs-release.yml
@@ -40,7 +40,7 @@ name: "Build Python source and docs artifacts"
 # Set from inputs for workflow_dispatch, or set defaults to test push/PR events
 env:
   GIT_REMOTE: ${{ github.event.inputs.git_remote || 'python' }}
-  GIT_COMMIT: ${{ github.event.inputs.git_commit || 'f6650f9ad73359051f3e558c2431a109bc016664' }}
+  GIT_COMMIT: ${{ github.event.inputs.git_commit || '4f8bb3947cfbc20f970ff9d9531e1132a9e95396' }}
   CPYTHON_RELEASE: ${{ github.event.inputs.cpython_release || '3.13.2' }}
 
 jobs:

--- a/.github/workflows/source-and-docs-release.yml
+++ b/.github/workflows/source-and-docs-release.yml
@@ -41,7 +41,7 @@ name: "Build Python source and docs artifacts"
 env:
   GIT_REMOTE: ${{ github.event.inputs.git_remote || 'python' }}
   GIT_COMMIT: ${{ github.event.inputs.git_commit || 'f6650f9ad73359051f3e558c2431a109bc016664' }}
-  CPYTHON_RELEASE: ${{ github.event.inputs.cpython_release || '3.12.3' }}
+  CPYTHON_RELEASE: ${{ github.event.inputs.cpython_release || '3.13.2' }}
 
 jobs:
   verify-input:


### PR DESCRIPTION
Re: https://github.com/python/release-tools/pull/212#issuecomment-2628865780

To fix the build for PRs. Release builds will set the version via an input. 