### PR TITLE
Bump pre-commit and fix zizmor's excessive-permissions warnings

### DIFF
--- a/.github/workflows/source-and-docs-release.yml
+++ b/.github/workflows/source-and-docs-release.yml
@@ -37,6 +37,8 @@ on:
 
 name: "Build Python source and docs artifacts"
 
+permissions: {}
+
 # Set from inputs for workflow_dispatch, or set defaults to test push/PR events
 env:
   GIT_REMOTE: ${{ github.event.inputs.git_remote || 'python' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
 
@@ -25,18 +25,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 0.31.1
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.4
+    rev: v1.7.7
     hooks:
       - id: actionlint
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v0.8.0
+    rev: v1.3.1
     hooks:
       - id: zizmor
 
@@ -51,7 +51,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.4.1
+    rev: 1.5.0
     hooks:
       - id: tox-ini-fmt
 
@@ -59,6 +59,3 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
-
-ci:
-  autoupdate_schedule: quarterly


### PR DESCRIPTION
```
warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/source-and-docs-release.yml:1:1
    |
  1 | / on:
  2 | |   push:
...   |
179 | |           cd ../installation
180 | |           ./bin/python3 -m test -uall
    | |______________________________________- default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/source-and-docs-release.yml:47:3
   |
47 | /   verify-input:
48 | |     runs-on: ubuntu-24.04
...  |
71 | |             exit 1
72 | |           fi
   | |            -
   | |____________|
   |              this job
   |              default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/source-and-docs-release.yml:74:3
    |
 74 | /   build-source:
 75 | |     runs-on: ubuntu-24.04
...   |
111 | |           path: |
112 | |             cpython/${{ env.CPYTHON_RELEASE }}/src
    | |                                                  -
    | |__________________________________________________|
    |                                                    this job
    |                                                    default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/source-and-docs-release.yml:114:3
    |
114 | /   build-docs:
115 | |     runs-on: ubuntu-24.04
...   |
154 | |           path: |
155 | |             Doc/dist/
    | |                     -
    | |_____________________|
    |                       this job
    |                       default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> .github/workflows/source-and-docs-release.yml:157:3
    |
157 | /   test-source:
158 | |     runs-on: ubuntu-24.04
...   |
179 | |           cd ../installation
180 | |           ./bin/python3 -m test -uall
    | |                                      -
    | |______________________________________|
    |                                        this job
    |                                        default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/test.yml:9:3
   |
 9 | /   tests:
10 | |     name: "Tests"
...  |
33 | |         with:
34 | |           token: ${{ secrets.CODECOV_ORG_TOKEN }}
   | |                                                  -
   | |__________________________________________________|
   |                                                    this job
   |                                                    default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

11 findings (5 suppressed): 0 unknown, 0 informational, 0 low, 6 medium, 0 high
```

https://woodruffw.github.io/zizmor/audits/#excessive-permissions

---

Also remove the config for https://pre-commit.ci/ because we haven't enabled it for this repo, and perhaps we shouldn't, as we need to be extra careful with this one?

```yml
ci:	
  autoupdate_schedule: quarterly	
```
