### PR TITLE
Show GH CLI command for starting build

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -874,7 +874,7 @@ def start_build_of_source_and_docs(db: ReleaseShelf) -> None:
     print()
     print("Or using the GitHub CLI run:")
     print(
-        f"  gh workflow run source-and-docs-release.yml --repo python/release-tools"
+        "  gh workflow run source-and-docs-release.yml --repo python/release-tools"
         f" -f git_remote={origin_remote_github_owner}"
         f" -f git_commit={commit_sha}"
         f" -f cpython_release={db['release']}"

--- a/run_release.py
+++ b/run_release.py
@@ -872,6 +872,14 @@ def start_build_of_source_and_docs(db: ReleaseShelf) -> None:
     print(f"- Git commit to target for the release: {commit_sha}")
     print(f"- CPython release number: {db['release']}")
     print()
+    print("Or using the GitHub CLI run:")
+    print(
+        f"  gh workflow run source-and-docs-release.yml --repo python/release-tools"
+        f" -f git_remote={origin_remote_github_owner}"
+        f" -f git_commit={commit_sha}"
+        f" -f cpython_release={db['release']}"
+    )
+    print()
 
     if not ask_question("Have you started the source and docs build?"):
         raise ReleaseException("Source and docs build must be started")


### PR DESCRIPTION
For https://github.com/python/release-tools/issues/108.

Prints the command needed to start a build using the GitHub CLI: https://github.com/cli/cli

For example, it will output something like this, the second bit is new:

```
Go to https://github.com/python/release-tools/actions/workflows/source-and-docs-release.yml
Select 'Run workflow' and enter the following values:
- Git remote to checkout: hugovk
- Git commit to target for the release: 240b882b2a17621c1a32eceb9227447be55ffb84
- CPython release number: 3.14.0a6

Or using the GitHub CLI run:
  gh workflow run source-and-docs-release.yml --repo python/release-tools -f git_remote=hugovk -f git_commit=240b882b2a17621c1a32eceb9227447be55ffb84 -f cpython_release=3.14.0a6
```

(We can later further automate by actually calling this: we'll need to make sure RMs have the tool installed -- if that's an acceptable requirement. Otherwise, via API calls, which will need token management etc. But first let's just print it.)