### PR TITLE
Log when starting to add files to python.org

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -953,6 +953,7 @@ def run_add_to_python_dot_org(db: ReleaseShelf) -> None:
     issuer = sigstore.oidc.Issuer(sigstore.oidc.DEFAULT_OAUTH_ISSUER_URL)
     identity_token = issuer.identity_token()
 
+    print("Adding files to python.org...")
     stdin, stdout, stderr = client.exec_command(
         f"AUTH_INFO={auth_info} SIGSTORE_IDENTITY_TOKEN={identity_token} python3 add_to_pydotorg.py {db['release']}"
     )


### PR DESCRIPTION
During the release, we get:

```
...
✅  Push new tags and branches to upstream
Deleted branch branch-3.14.0a6 (was 77b2c933cab).
✅  Removing temporary release branch
Waiting for browser interaction...
```
The browser then opens with a Sigstore page. I authorise Sigstore, then it says the page can be closed. I close it and go back to the terminal.

It then sits at "Waiting for browser interaction..." for a while, which is a bit confusing as we've just done that. It seems like it's hung, but it's not, as eventually it shows:

```
✅  Push new tags and branches to upstream
Deleted branch branch-3.14.0a6 (was 77b2c933cab).
✅  Removing temporary release branch
Waiting for browser interaction...
-- Command output --
Using ephemeral certificate:
-----BEGIN CERTIFICATE-----
MIICzzCCAlSgAwIBAgIUEwYStfT1rq5xVQepvaGvrMg8sy4wCgYIKoZIzj0EAwMw
NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
...
[then a lot more stuff]
...
Done - 9 files added

-- End of command output --
✅  Add files to python.org download page
```

Which is the result of adding the files to python.org.

Because we don't get realtime prints, let's add an extra print to show it has begun.
