### PR TITLE
Automatically bump the README version

### DIFF
--- a/release.py
+++ b/release.py
@@ -439,7 +439,7 @@ def tweak_readme(tag: Tag, filename: str = "README.rst") -> None:
     # and update length of underline in second line to match.
     lines = readme.read_text().splitlines()
     this_is = f"This is Python version {tag.long_name}"
-    underline = f"{'=' * len(this_is)}"
+    underline = "=" * len(this_is)
     lines[0] = this_is
     lines[1] = underline
 

--- a/release.py
+++ b/release.py
@@ -190,6 +190,18 @@ class Tag:
     def gitname(self) -> str:
         return "v" + self.text
 
+    @property
+    def long_name(self) -> str:
+        if self.is_final:
+            return self.text
+
+        level = {
+            "a": "alpha",
+            "b": "beta",
+            "rc": "release candidate",
+        }[self.level]
+        return f"{self.normalized()} {level} {self.serial}"
+
     def next_minor_release(self) -> Self:
         return self.__class__(f"{self.major}.{int(self.minor)+1}.0a0")
 

--- a/release.py
+++ b/release.py
@@ -431,13 +431,30 @@ def tweak_patchlevel(
     print("done")
 
 
+def tweak_readme(tag: Tag, filename: str = "README.rst") -> None:
+    print(f"Updating {filename}...", end=" ")
+    readme = Path(filename)
+
+    # Update first line: "This is Python version 3.14.0 alpha 7"
+    # and update length of underline in second line to match.
+    lines = readme.read_text().splitlines()
+    this_is = f"This is Python version {tag.long_name}"
+    underline = f"{'=' * len(this_is)}"
+    lines[0] = this_is
+    lines[1] = underline
+
+    readme.write_text("\n".join(lines))
+    print("done")
+
+
 def bump(tag: Tag) -> None:
     print(f"Bumping version to {tag}")
 
     tweak_patchlevel(tag)
+    tweak_readme(tag)
 
     extra_work = False
-    other_files = ["README.rst"]
+    other_files = []
     if tag.patch == 0 and tag.level == "a" and tag.serial == 0:
         extra_work = True
         other_files += [

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,0 +1,235 @@
+This is Python version 3.14.0 alpha 3
+=====================================
+
+.. image:: https://github.com/python/cpython/actions/workflows/build.yml/badge.svg?branch=main&event=push
+   :alt: CPython build status on GitHub Actions
+   :target: https://github.com/python/cpython/actions
+
+.. image:: https://dev.azure.com/python/cpython/_apis/build/status/Azure%20Pipelines%20CI?branchName=main
+   :alt: CPython build status on Azure DevOps
+   :target: https://dev.azure.com/python/cpython/_build/latest?definitionId=4&branchName=main
+
+.. image:: https://img.shields.io/badge/discourse-join_chat-brightgreen.svg
+   :alt: Python Discourse chat
+   :target: https://discuss.python.org/
+
+
+Copyright © 2001 Python Software Foundation.  All rights reserved.
+
+See the end of this file for further copyright and license information.
+
+.. contents::
+
+General Information
+-------------------
+
+- Website: https://www.python.org
+- Source code: https://github.com/python/cpython
+- Issue tracker: https://github.com/python/cpython/issues
+- Documentation: https://docs.python.org
+- Developer's Guide: https://devguide.python.org/
+
+Contributing to CPython
+-----------------------
+
+For more complete instructions on contributing to CPython development,
+see the `Developer Guide`_.
+
+.. _Developer Guide: https://devguide.python.org/
+
+Using Python
+------------
+
+Installable Python kits, and information about using Python, are available at
+`python.org`_.
+
+.. _python.org: https://www.python.org/
+
+Build Instructions
+------------------
+
+On Unix, Linux, BSD, macOS, and Cygwin::
+
+    ./configure
+    make
+    make test
+    sudo make install
+
+This will install Python as ``python3``.
+
+You can pass many options to the configure script; run ``./configure --help``
+to find out more.  On macOS case-insensitive file systems and on Cygwin,
+the executable is called ``python.exe``; elsewhere it's just ``python``.
+
+Building a complete Python installation requires the use of various
+additional third-party libraries, depending on your build platform and
+configure options.  Not all standard library modules are buildable or
+usable on all platforms.  Refer to the
+`Install dependencies <https://devguide.python.org/getting-started/setup-building.html#build-dependencies>`_
+section of the `Developer Guide`_ for current detailed information on
+dependencies for various Linux distributions and macOS.
+
+On macOS, there are additional configure and build options related
+to macOS framework and universal builds.  Refer to `Mac/README.rst
+<https://github.com/python/cpython/blob/main/Mac/README.rst>`_.
+
+On Windows, see `PCbuild/readme.txt
+<https://github.com/python/cpython/blob/main/PCbuild/readme.txt>`_.
+
+To build Windows installer, see `Tools/msi/README.txt
+<https://github.com/python/cpython/blob/main/Tools/msi/README.txt>`_.
+
+If you wish, you can create a subdirectory and invoke configure from there.
+For example::
+
+    mkdir debug
+    cd debug
+    ../configure --with-pydebug
+    make
+    make test
+
+(This will fail if you *also* built at the top-level directory.  You should do
+a ``make clean`` at the top-level first.)
+
+To get an optimized build of Python, ``configure --enable-optimizations``
+before you run ``make``.  This sets the default make targets up to enable
+Profile Guided Optimization (PGO) and may be used to auto-enable Link Time
+Optimization (LTO) on some platforms.  For more details, see the sections
+below.
+
+Profile Guided Optimization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PGO takes advantage of recent versions of the GCC or Clang compilers.  If used,
+either via ``configure --enable-optimizations`` or by manually running
+``make profile-opt`` regardless of configure flags, the optimized build
+process will perform the following steps:
+
+The entire Python directory is cleaned of temporary files that may have
+resulted from a previous compilation.
+
+An instrumented version of the interpreter is built, using suitable compiler
+flags for each flavor. Note that this is just an intermediary step.  The
+binary resulting from this step is not good for real-life workloads as it has
+profiling instructions embedded inside.
+
+After the instrumented interpreter is built, the Makefile will run a training
+workload.  This is necessary in order to profile the interpreter's execution.
+Note also that any output, both stdout and stderr, that may appear at this step
+is suppressed.
+
+The final step is to build the actual interpreter, using the information
+collected from the instrumented one.  The end result will be a Python binary
+that is optimized; suitable for distribution or production installation.
+
+
+Link Time Optimization
+^^^^^^^^^^^^^^^^^^^^^^
+
+Enabled via configure's ``--with-lto`` flag.  LTO takes advantage of the
+ability of recent compiler toolchains to optimize across the otherwise
+arbitrary ``.o`` file boundary when building final executables or shared
+libraries for additional performance gains.
+
+
+What's New
+----------
+
+We have a comprehensive overview of the changes in the `What's New in Python
+3.14 <https://docs.python.org/3.14/whatsnew/3.14.html>`_ document.  For a more
+detailed change log, read `Misc/NEWS
+<https://github.com/python/cpython/tree/main/Misc/NEWS.d>`_, but a full
+accounting of changes can only be gleaned from the `commit history
+<https://github.com/python/cpython/commits/main>`_.
+
+If you want to install multiple versions of Python, see the section below
+entitled "Installing multiple versions".
+
+
+Documentation
+-------------
+
+`Documentation for Python 3.14 <https://docs.python.org/3.14/>`_ is online,
+updated daily.
+
+It can also be downloaded in many formats for faster access.  The documentation
+is downloadable in HTML, PDF, and reStructuredText formats; the latter version
+is primarily for documentation authors, translators, and people with special
+formatting requirements.
+
+For information about building Python's documentation, refer to `Doc/README.rst
+<https://github.com/python/cpython/blob/main/Doc/README.rst>`_.
+
+
+Testing
+-------
+
+To test the interpreter, type ``make test`` in the top-level directory.  The
+test set produces some output.  You can generally ignore the messages about
+skipped tests due to optional features which can't be imported.  If a message
+is printed about a failed test or a traceback or core dump is produced,
+something is wrong.
+
+By default, tests are prevented from overusing resources like disk space and
+memory.  To enable these tests, run ``make buildbottest``.
+
+If any tests fail, you can re-run the failing test(s) in verbose mode.  For
+example, if ``test_os`` and ``test_gdb`` failed, you can run::
+
+    make test TESTOPTS="-v test_os test_gdb"
+
+If the failure persists and appears to be a problem with Python rather than
+your environment, you can `file a bug report
+<https://github.com/python/cpython/issues>`_ and include relevant output from
+that command to show the issue.
+
+See `Running & Writing Tests <https://devguide.python.org/testing/run-write-tests.html>`_
+for more on running tests.
+
+Installing multiple versions
+----------------------------
+
+On Unix and Mac systems if you intend to install multiple versions of Python
+using the same installation prefix (``--prefix`` argument to the configure
+script) you must take care that your primary python executable is not
+overwritten by the installation of a different version.  All files and
+directories installed using ``make altinstall`` contain the major and minor
+version and can thus live side-by-side.  ``make install`` also creates
+``${prefix}/bin/python3`` which refers to ``${prefix}/bin/python3.X``.  If you
+intend to install multiple versions using the same prefix you must decide which
+version (if any) is your "primary" version.  Install that version using
+``make install``.  Install all other versions using ``make altinstall``.
+
+For example, if you want to install Python 2.7, 3.6, and 3.14 with 3.14 being the
+primary version, you would execute ``make install`` in your 3.14 build directory
+and ``make altinstall`` in the others.
+
+
+Release Schedule
+----------------
+
+See `PEP 745 <https://peps.python.org/pep-0745/>`__ for Python 3.14 release details.
+
+
+Copyright and License Information
+---------------------------------
+
+
+Copyright © 2001 Python Software Foundation.  All rights reserved.
+
+Copyright © 2000 BeOpen.com.  All rights reserved.
+
+Copyright © 1995-2001 Corporation for National Research Initiatives.  All
+rights reserved.
+
+Copyright © 1991-1995 Stichting Mathematisch Centrum.  All rights reserved.
+
+See the `LICENSE <https://github.com/python/cpython/blob/main/LICENSE>`_ for
+information on the history of this software, terms & conditions for usage, and a
+DISCLAIMER OF ALL WARRANTIES.
+
+This Python distribution contains *no* GNU General Public License (GPL) code,
+so it may be used in proprietary projects.  There are interfaces to some GNU
+code but these are entirely optional.
+
+All trademarks referenced herein are property of their respective holders.

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -68,3 +68,50 @@ def test_tweak_patchlevel(tmp_path: Path) -> None:
         '#define PY_VERSION              "3.14.0b2"',
     ):
         assert expected in new_contents
+
+
+@pytest.mark.parametrize(
+    ["test_tag", "expected_version", "expected_underline"],
+    [
+        (
+            "3.14.0a6",
+            "This is Python version 3.14.0 alpha 6",
+            "=====================================",
+        ),
+        (
+            "3.14.0b2",
+            "This is Python version 3.14.0 beta 2",
+            "====================================",
+        ),
+        (
+            "3.14.0rc2",
+            "This is Python version 3.14.0 release candidate 2",
+            "=================================================",
+        ),
+        (
+            "3.14.1",
+            "This is Python version 3.14.1",
+            "=============================",
+        ),
+    ],
+)
+def test_tweak_readme(
+    tmp_path: Path, test_tag: str, expected_version: str, expected_underline: str
+) -> None:
+    # Arrange
+    tag = release.Tag(test_tag)
+
+    original_readme_file = Path(__file__).parent / "README.rst"
+    original_contents = original_readme_file.read_text()
+    readme_file = tmp_path / "README.rst"
+    readme_file.write_text(original_contents)
+
+    # Act
+    release.tweak_readme(tag, filename=str(readme_file))
+
+    # Assert
+    original_lines = original_contents.splitlines()
+    new_lines = readme_file.read_text().splitlines()
+    assert new_lines[0] == expected_version
+    assert new_lines[1] == expected_underline
+    assert new_lines[2:] == original_lines[2:]

--- a/tests/test_release_tag.py
+++ b/tests/test_release_tag.py
@@ -32,23 +32,33 @@ def test_tag_phase() -> None:
     beta1 = release.Tag("3.13.0b1")
     beta4 = release.Tag("3.13.0b4")
     rc = release.Tag("3.13.0rc3")
+    final = release.Tag("3.13.0")
 
     # Act / Assert
     assert alpha.is_alpha_release is True
     assert alpha.is_feature_freeze_release is False
     assert alpha.is_release_candidate is False
+    assert alpha.is_final is False
 
     assert beta1.is_alpha_release is False
     assert beta1.is_feature_freeze_release is True
     assert beta1.is_release_candidate is False
+    assert beta1.is_final is False
 
     assert beta4.is_alpha_release is False
     assert beta4.is_feature_freeze_release is False
     assert beta4.is_release_candidate is False
+    assert beta4.is_final is False
 
     assert rc.is_alpha_release is False
     assert rc.is_feature_freeze_release is False
     assert rc.is_release_candidate is True
+    assert rc.is_final is False
+
+    assert final.is_alpha_release is False
+    assert final.is_feature_freeze_release is False
+    assert final.is_release_candidate is False
+    assert final.is_final is True
 
 
 def test_tag_committed_at_not_found() -> None:

--- a/tests/test_release_tag.py
+++ b/tests/test_release_tag.py
@@ -19,6 +19,7 @@ def test_tag() -> None:
     assert tag.as_tuple() == (3, 12, 2, "f", 0)
     assert tag.branch == "3.12"
     assert tag.gitname == "v3.12.2"
+    assert tag.long_name == "3.12.2"
     assert tag.is_alpha_release is False
     assert tag.is_feature_freeze_release is False
     assert tag.is_release_candidate is False
@@ -123,3 +124,19 @@ def test_tag_docs_attributes() -> None:
     assert rc.doc_version == "3.13"
     assert final_zero.doc_version == "3.13"
     assert final_3.doc_version == "3.13.3"
+
+
+def test_tag_long_name() -> None:
+    # Arrange
+    alpha = release.Tag("3.13.0a7")
+    beta = release.Tag("3.13.0b1")
+    rc = release.Tag("3.13.0rc3")
+    final_zero = release.Tag("3.13.0")
+    final_3 = release.Tag("3.13.3")
+
+    # Act / Assert
+    assert alpha.long_name == "3.13.0 alpha 7"
+    assert beta.long_name == "3.13.0 beta 1"
+    assert rc.long_name == "3.13.0 release candidate 3"
+    assert final_zero.long_name == "3.13.0"
+    assert final_3.long_name == "3.13.3"


### PR DESCRIPTION
Add a function `tweak_readme` to open `README.rst`, update the first line to (for example) "This is Python version 3.14.0 alpha 7" and update the underline to be the same length.

Also add some tests for `Tag.is_final`.