### PR TITLE
Prompt to update the docs by version page

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -1014,21 +1014,21 @@ def purge_the_cdn(db: ReleaseShelf) -> None:
             raise RuntimeError("Failed to purge the python.org/downloads CDN")
 
 
-def modify_the_release_to_the_prerelease_pages(db: ReleaseShelf) -> None:
+def modify_the_prereleases_page(db: ReleaseShelf) -> None:
     pre_release_tags = {"rc", "b", "a"}
     if any(tag in str(db["release"]) for tag in pre_release_tags):
         if not ask_question(
-            "Have you already added the release to https://www.python.org/download/pre-releases/"
+            "Have you already added the release to https://www.python.org/download/pre-releases/ ?"
         ):
             raise ReleaseException(
-                "The release has not been added to the pre-release page"
+                "The release has not been added to the pre-releases page"
             )
     else:
         if not ask_question(
-            "Have you already removed the release from https://www.python.org/download/pre-releases/"
+            "Have you already removed the release from https://www.python.org/download/pre-releases/ ?"
         ):
             raise ReleaseException(
-                "The release has not been removed from the pre-release page"
+                "The release has not been removed from the pre-releases page"
             )
 
 
@@ -1345,7 +1345,7 @@ fix these things in this script so it also supports your platform.
         Task(remove_temporary_branch, "Removing temporary release branch"),
         Task(run_add_to_python_dot_org, "Add files to python.org download page"),
         Task(purge_the_cdn, "Purge the CDN of python.org/downloads"),
-        Task(modify_the_release_to_the_prerelease_pages, "Modify the pre-release page"),
+        Task(modify_the_prereleases_page, "Modify the pre-release page"),
         Task(modify_the_docs_by_version_page, "Update docs by version page"),
     ]
     automata = ReleaseDriver(

--- a/run_release.py
+++ b/run_release.py
@@ -1015,20 +1015,19 @@ def purge_the_cdn(db: ReleaseShelf) -> None:
 
 
 def modify_the_prereleases_page(db: ReleaseShelf) -> None:
-    pre_release_tags = {"rc", "b", "a"}
-    if any(tag in str(db["release"]) for tag in pre_release_tags):
-        if not ask_question(
-            "Have you already added the release to https://www.python.org/download/pre-releases/ ?"
-        ):
-            raise ReleaseException(
-                "The release has not been added to the pre-releases page"
-            )
-    else:
+    if db["release"].is_final:
         if not ask_question(
             "Have you already removed the release from https://www.python.org/download/pre-releases/ ?"
         ):
             raise ReleaseException(
                 "The release has not been removed from the pre-releases page"
+            )
+    else:
+        if not ask_question(
+            "Have you already added the release to https://www.python.org/download/pre-releases/ ?"
+        ):
+            raise ReleaseException(
+                "The release has not been added to the pre-releases page"
             )
 
 

--- a/run_release.py
+++ b/run_release.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import datetime as dt
 import functools
 import getpass
 import json
@@ -1031,6 +1032,21 @@ def modify_the_release_to_the_prerelease_pages(db: ReleaseShelf) -> None:
             )
 
 
+def modify_the_docs_by_version_page(db: ReleaseShelf) -> None:
+    if db["release"].is_final:
+        version = db["release"]
+        date = dt.datetime.now().strftime("%d %B %Y")
+        if not ask_question(
+            "Have you already added the docs to https://www.python.org/doc/versions/ ?\n"
+            "For example:\n"
+            f"* `Python {version} <https://docs.python.org/release/{version}/>`_, "
+            f"documentation released on {date}."
+        ):
+            raise ReleaseException(
+                "The docs have not been added to the docs by version page"
+            )
+
+
 def post_release_merge(db: ReleaseShelf) -> None:
     subprocess.check_call(
         ["git", "fetch", "--all"],
@@ -1330,6 +1346,7 @@ fix these things in this script so it also supports your platform.
         Task(run_add_to_python_dot_org, "Add files to python.org download page"),
         Task(purge_the_cdn, "Purge the CDN of python.org/downloads"),
         Task(modify_the_release_to_the_prerelease_pages, "Modify the pre-release page"),
+        Task(modify_the_docs_by_version_page, "Update docs by version page"),
     ]
     automata = ReleaseDriver(
         git_repo=args.repo,


### PR DESCRIPTION
Fixes https://github.com/python/release-tools/issues/165.

Prompt to update https://www.python.org/doc/versions, which is often forgotten.

Print out the reStructuredText needed for pasting into the page.

Refactor the similar prereleases page function to also use `Tag.is_final` and simplify name.