### PR TITLE
Enables Windows OpenSSL build to run on custom VM

### DIFF
--- a/windows-release/openssl-build.yml
+++ b/windows-release/openssl-build.yml
@@ -14,6 +14,26 @@ parameters:
   displayName: 'Sources Repository'
   type: string
   default: 'https://github.com/python/cpython-source-deps'
+- name: CustomBuildVM
+  displayName: 'Custom build VM'
+  type: boolean
+  default: false
+- name: VCVarsOptions
+  displayName: 'vcvarsall.bat options'
+  type: string
+  default: '(none)'
+- name: IncludeX86
+  displayName: 'Include x86'
+  type: boolean
+  default: true
+- name: IncludeX64
+  displayName: 'Include x64'
+  type: boolean
+  default: true
+- name: IncludeARM64
+  displayName: 'Include ARM64'
+  type: boolean
+  default: true
 
 
 name: ${{ parameters.SourceTag }}_$(Date:yyyyMMdd)$(Rev:.rr)
@@ -36,22 +56,28 @@ jobs:
 - job: Build_SSL
   displayName: OpenSSL
   pool:
-    vmImage: windows-latest
+    ${{ if eq(parameters.CustomBuildVM, 'true') }}:
+      name: 'Windows Release'
+    ${{ else }}:
+      vmImage: windows-latest
 
   strategy:
     matrix:
-      win32:
-        Platform: 'win32'
-        VCPlatform: 'amd64_x86'
-        OpenSSLPlatform: 'VC-WIN32 no-asm'
-      amd64:
-        Platform: 'amd64'
-        VCPlatform: 'amd64'
-        OpenSSLPlatform: 'VC-WIN64A-masm'
-      arm64:
-        Platform: 'arm64'
-        VCPlatform: 'amd64_arm64'
-        OpenSSLPlatform: 'VC-WIN64-ARM'
+      ${{ if eq(parameters.IncludeX86, 'true') }}:
+        win32:
+          Platform: 'win32'
+          VCPlatform: 'amd64_x86'
+          OpenSSLPlatform: 'VC-WIN32 no-asm'
+      ${{ if eq(parameters.IncludeX64, 'true') }}:
+        amd64:
+          Platform: 'amd64'
+          VCPlatform: 'amd64'
+          OpenSSLPlatform: 'VC-WIN64A-masm'
+      ${{ if eq(parameters.IncludeARM64, 'true') }}:
+        arm64:
+          Platform: 'arm64'
+          VCPlatform: 'amd64_arm64'
+          OpenSSLPlatform: 'VC-WIN64-ARM'
 
   workspace:
     clean: all
@@ -66,11 +92,14 @@ jobs:
       displayName: 'Check out OpenSSL sources'
 
     - script: |
-        call "$(vcvarsall)" $(VCPlatform)
+        call "$(vcvarsall)" $(VCPlatform) %EXTRA_OPTS%
         perl "$(Build.SourcesDirectory)\Configure" $(OpenSSLPlatform) no-uplink
         nmake
       workingDirectory: '$(IntDir)'
       displayName: 'Build OpenSSL'
+      env:
+        ${{ if ne(parameters.VCVarsOptions, '(none)') }}:
+          EXTRA_OPTS: ${{ parameters.VCVarsOptions }}
 
     - ${{ if ne(parameters.SigningCertificate, 'Unsigned') }}:
       - template: sign-files.yml


### PR DESCRIPTION
We need this ability temporarily to work around a [compiler bug in MSVC 14.43](https://developercommunity.visualstudio.com/t/ARM64-stack-corruption-in-1443-in-OpenS/10883345?viewtype=all) (fine in 14.40 and apparently fixed in not-yet-released 14.44).

Adding VMs to the "Windows Release" pool requires admin permissions on dev.azure.com/python, and I intend to remove my current machine once we've done the new build, so while this does technically weaken our supply chain, in practical terms it isn't going to have any impact. More people have the ability to modify the build scripts than the build configuration, anyway.

The "vcvarsall.bat options" parameter is for something like `--vcvars_ver=14.44` to override the compiler version (which is _not_ a reliable option, as it relies on precisely the right install layout... but it's the best we've got for OpenSSL...)