### PR TITLE
Skip symlinks when creating SBOM for source tarball

### DIFF
--- a/sbom.py
+++ b/sbom.py
@@ -608,7 +608,7 @@ def create_sbom_for_source_tarball(tarball_path: str) -> SBOM:
     # Now we walk the tarball and compare known files to our expected checksums in the SBOM.
     # All files that aren't already in the SBOM can be added as "CPython" files.
     for member in tarball.getmembers():
-        if member.isdir() or not member.isfile():  # Skip directories and symlinks!
+        if not member.isfile():  # Only keep files (no symlinks)
             continue
 
         # Get the member from the tarball. CPython prefixes all of its

--- a/sbom.py
+++ b/sbom.py
@@ -608,12 +608,12 @@ def create_sbom_for_source_tarball(tarball_path: str) -> SBOM:
     # Now we walk the tarball and compare known files to our expected checksums in the SBOM.
     # All files that aren't already in the SBOM can be added as "CPython" files.
     for member in tarball.getmembers():
-        if member.isdir():  # Skip directories!
+        if member.isdir() or not member.isfile():  # Skip directories and symlinks!
             continue
 
         # Get the member from the tarball. CPython prefixes all of its
         # source code with 'Python-{version}/...'.
-        assert member.isfile() and member.name.startswith(f"Python-{cpython_version}/")
+        assert member.name.startswith(f"Python-{cpython_version}/")
 
         # Calculate the hashes, either for comparison with a known value
         # or to embed in the SBOM as a new file. SHA1 is only used because


### PR DESCRIPTION
```pytb
Building an SBOM for artifact 'Python-3.14.0a7.tgz'
💥  Building SBOM artifacts
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1388, in <module>
    main()
  File "/Users/hugo/github/release-tools/run_release.py", line 1384, in main
    automata.run()
  File "/Users/hugo/github/release-tools/run_release.py", line 248, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 245, in run
    self.current_task(self.db)
  File "/Users/hugo/github/release-tools/release.py", line 126, in __call__
    return getattr(self, "function")(db)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 656, in build_sbom_artifacts
    sbom_data = sbom.create_sbom_for_source_tarball(tarball_path)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/release-tools/sbom.py", line 616, in create_sbom_for_source_tarball
    assert member.isfile() and member.name.startswith(f"Python-{cpython_version}/")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

That's because `Python-3.14.0a7/Misc/mypy/_colorize.py` is a symlink and `member.isfile()` is `False`.

Because https://github.com/python/cpython/tree/main/Misc/mypy now has symlinks, added in https://github.com/python/cpython/pull/131509.

Let's skip them.
