### PR TITLE
Delete Misc/mypy during the building of the tarball

### DIFF
--- a/release.py
+++ b/release.py
@@ -635,7 +635,7 @@ def export(tag: Tag, silent: bool = False, skip_docs: bool = False) -> None:
 
             # Remove directories we don't want to ship in tarballs.
             run_cmd(["blurb", "export"], silent=silent)
-            for name in (".azure-pipelines", ".git", ".github", ".hg"):
+            for name in (".azure-pipelines", ".git", ".github", ".hg", "Misc/mypy"):
                 shutil.rmtree(name, ignore_errors=True)
 
         if not skip_docs and (tag.is_final or tag.level == "rc"):


### PR DESCRIPTION
Delete Misc/mypy during the building of the tarball, as it only exists to run mypy in developer workflows / GitHub Workflows and contains symlinks, which SBOM generation gets confused about.