### PR TITLE
Print summary of commit SHA and tag to email RMs

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -906,7 +906,6 @@ def send_email_to_platform_release_managers(db: ReleaseShelf) -> None:
 
     print()
     print(f"{github_prefix}/{db['release'].gitname}")
-    print(f"{github_prefix}/branch-{db['release']}")
     print(f"Git commit SHA: {commit_sha}")
     print(
         "Source/docs build: https://github.com/python/release-tools/actions/runs/[ENTER-RUN-ID-HERE]"


### PR DESCRIPTION
During the release process, after starting the source/docs build, we need to send some info to the macOS and Windows RMs so they can start building the installers.

Rather than manually copying and pasting from different places, let's output an easy summary to send off.

I tested this by using it during the 3.14.0a7 release.

# Before

```
Have you started the source and docs build?
Enter yes or no: yes
✅  Start the builds for source and docs artifacts
Have you notified the platform release managers about the availability of the commit SHA and tag?
Enter yes or no: yes
```

# After

```
Have you started the source and docs build?
Enter yes or no: yes
✅  Start the builds for source and docs artifacts

https://github.com/hugovk/cpython/tree/v3.14.0a7
https://github.com/hugovk/cpython/tree/branch-3.14.0a7
Git commit SHA: 29af6cee02fbe74d59c6d725a506fe60c77d37d6
Source/docs build: https://github.com/python/release-tools/actions/runs/[ENTER-RUN-ID-HERE]

Have you notified the platform release managers about the availability of the commit SHA and tag?
Enter yes or no: yes
```