### PR TITLE
Add Windows release options for JIT builds

### DIFF
--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -41,6 +41,10 @@ parameters:
   displayName: "Signature description"
   type: string
   default: '(default)'
+- name: DoJIT
+  displayName: "Build the JIT compiler (3.14 and later)"
+  type: boolean
+  default: false
 - name: DoGPG
   displayName: "Include GPG signatures (3.13 and earlier)"
   type: boolean
@@ -49,18 +53,6 @@ parameters:
   displayName: "Include free-threaded builds (3.13 and later)"
   type: boolean
   default: true
-- name: DoJIT
-  displayName: "Build the JIT compiler (3.14 and later)"
-  type: boolean
-  default: false
-- name: DoJITEnabled
-  displayName: "Enable the JIT compiler by default (not used yet)"
-  type: boolean
-  default: false
-- name: DoJITFreethreaded
-  displayName: "Build the JIT compiler for free-threaded builds (not used yet)"
-  type: boolean
-  default: false
 - name: DoARM64
   displayName: "Publish ARM64 build (3.11 and later)"
   type: boolean
@@ -111,6 +103,14 @@ parameters:
   displayName: "Enable Nuget signing (not recommended right now)"
   type: boolean
   default: false
+- name: DoJITEnabled
+  displayName: "Enable the JIT compiler by default (not used yet)"
+  type: boolean
+  default: false
+- name: DoJITFreethreaded
+  displayName: "Build the JIT compiler for free-threaded builds (not used yet)"
+  type: boolean
+  default: false
 
 resources:
   pipelines:
@@ -149,13 +149,22 @@ stages:
     - template: stage-build.yml
       parameters:
         DoFreethreaded: ${{ parameters.DoFreethreaded }}
-        DoJIT: ${{ parameters.DoJIT }}
-        DoJITEnabled: ${{ parameters.DoJITEnabled }}
-        DoJITFreethreaded: ${{ parameters.DoJITFreethreaded }}
         DoPGO: ${{ parameters.DoPGO }}
         DoPGOARM64: ${{ parameters.DoPGOARM64 }}
         ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
           ToBeSigned: true
+        ${{ if ne(parameters.DoJIT, 'true') }}:
+          JITOption: ''
+        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+          JITOption: '--experimental-jit-off'
+        ${{ else }}:
+          JITOption: '--experimental-jit'
+        ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+          JITOptionFreethreaded: ''
+        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+          JITOptionFreethreaded: '--experimental-jit-off'
+        ${{ else }}:
+          JITOptionFreethreaded: '--experimental-jit'
 
   - stage: Sign
     displayName: Sign binaries

--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -49,6 +49,18 @@ parameters:
   displayName: "Include free-threaded builds (3.13 and later)"
   type: boolean
   default: true
+- name: DoJIT
+  displayName: "Build the JIT compiler (3.14 and later)"
+  type: boolean
+  default: false
+- name: DoJITEnabled
+  displayName: "Enable the JIT compiler by default (not used yet)"
+  type: boolean
+  default: false
+- name: DoJITFreethreaded
+  displayName: "Build the JIT compiler for free-threaded builds (not used yet)"
+  type: boolean
+  default: false
 - name: DoARM64
   displayName: "Publish ARM64 build (3.11 and later)"
   type: boolean
@@ -137,6 +149,9 @@ stages:
     - template: stage-build.yml
       parameters:
         DoFreethreaded: ${{ parameters.DoFreethreaded }}
+        DoJIT: ${{ parameters.DoJIT }}
+        DoJITEnabled: ${{ parameters.DoJITEnabled }}
+        DoJITFreethreaded: ${{ parameters.DoJITFreethreaded }}
         DoPGO: ${{ parameters.DoPGO }}
         DoPGOARM64: ${{ parameters.DoPGOARM64 }}
         ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:

--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -154,17 +154,17 @@ stages:
         ${{ if and(parameters.SigningCertificate, ne(parameters.SigningCertificate, 'Unsigned')) }}:
           ToBeSigned: true
         ${{ if ne(parameters.DoJIT, 'true') }}:
-          JITOption: ''
+          ExtraOptions: ''
         ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-          JITOption: '--experimental-jit-off'
+          ExtraOptions: '--experimental-jit-off'
         ${{ else }}:
-          JITOption: '--experimental-jit'
+          ExtraOptions: '--experimental-jit'
         ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-          JITOptionFreethreaded: ''
+          ExtraOptionsFreethreaded: '--disable-gil'
         ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-          JITOptionFreethreaded: '--experimental-jit-off'
+          ExtraOptionsFreethreaded: '--disable-gil --experimental-jit-off'
         ${{ else }}:
-          JITOptionFreethreaded: '--experimental-jit'
+          ExtraOptionsFreethreaded: '--disable-gil --experimental-jit'
 
   - stage: Sign
     displayName: Sign binaries

--- a/windows-release/stage-build.yml
+++ b/windows-release/stage-build.yml
@@ -4,6 +4,9 @@ parameters:
   DoPGOARM64: true
   DoFreethreaded: false
   ToBeSigned: false
+  DoJIT: false
+  DoJITEnabled: false
+  DoJITFreethreaded: false
 
 jobs:
 - job: Build_Docs
@@ -52,7 +55,12 @@ jobs:
         Platform: x86
         Configuration: Release
         _HostPython: .\python
-        ExtraOptions: ''
+        ${{ if ne(parameters.DoJIT, 'true') }}:
+          ExtraOptions: ''
+        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+          ExtraOptions: '--experimental-jit-off'
+        ${{ else }}:
+          ExtraOptions: '--experimental-jit'
         ${{ if eq(parameters.ToBeSigned, 'true') }}:
           Artifact: unsigned_win32
         ${{ else }}:
@@ -63,7 +71,12 @@ jobs:
         Platform: x86
         Configuration: Debug
         _HostPython: .\python
-        ExtraOptions: ''
+        ${{ if ne(parameters.DoJIT, 'true') }}:
+          ExtraOptions: ''
+        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+          ExtraOptions: '--experimental-jit-off'
+        ${{ else }}:
+          ExtraOptions: '--experimental-jit'
         Artifact: bin_win32_d
       ${{ if ne(parameters.DoPGO, 'true') }}:
         amd64:
@@ -72,7 +85,12 @@ jobs:
           Platform: x64
           Configuration: Release
           _HostPython: .\python
-          ExtraOptions: ''
+          ${{ if ne(parameters.DoJIT, 'true') }}:
+            ExtraOptions: ''
+          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+            ExtraOptions: '--experimental-jit-off'
+          ${{ else }}:
+            ExtraOptions: '--experimental-jit'
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_amd64
           ${{ else }}:
@@ -83,7 +101,12 @@ jobs:
         Platform: x64
         Configuration: Debug
         _HostPython: .\python
-        ExtraOptions: ''
+        ${{ if ne(parameters.DoJIT, 'true') }}:
+          ExtraOptions: ''
+        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+          ExtraOptions: '--experimental-jit-off'
+        ${{ else }}:
+          ExtraOptions: '--experimental-jit'
         Artifact: bin_amd64_d
       ${{ if or(ne(parameters.DoPGO, 'true'), ne(parameters.DoPGOARM64, 'true')) }}:
         arm64:
@@ -92,7 +115,12 @@ jobs:
           Platform: ARM64
           Configuration: Release
           _HostPython: python
-          ExtraOptions: ''
+          ${{ if ne(parameters.DoJIT, 'true') }}:
+            ExtraOptions: ''
+          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+            ExtraOptions: '--experimental-jit-off'
+          ${{ else }}:
+            ExtraOptions: '--experimental-jit'
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_arm64
           ${{ else }}:
@@ -103,7 +131,12 @@ jobs:
         Platform: ARM64
         Configuration: Debug
         _HostPython: python
-        ExtraOptions: ''
+        ${{ if ne(parameters.DoJIT, 'true') }}:
+          ExtraOptions: ''
+        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+          ExtraOptions: '--experimental-jit-off'
+        ${{ else }}:
+          ExtraOptions: '--experimental-jit'
         Artifact: bin_arm64_d
       ${{ if eq(parameters.DoFreethreaded, 'true') }}:
         win32_t:
@@ -112,7 +145,12 @@ jobs:
           Platform: x86
           Configuration: Release
           _HostPython: .\python
-          ExtraOptions: --disable-gil
+          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+            ExtraOptions: '--disable-gil'
+          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+            ExtraOptions: '--disable-gil --experimental-jit-off'
+          ${{ else }}:
+            ExtraOptions: '--disable-gil --experimental-jit'
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_win32_t
           ${{ else }}:
@@ -123,7 +161,12 @@ jobs:
           Platform: x86
           Configuration: Debug
           _HostPython: .\python
-          ExtraOptions: --disable-gil
+          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+            ExtraOptions: '--disable-gil'
+          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+            ExtraOptions: '--disable-gil --experimental-jit-off'
+          ${{ else }}:
+            ExtraOptions: '--disable-gil --experimental-jit'
           Artifact: bin_win32_td
         ${{ if ne(parameters.DoPGO, 'true') }}:
           amd64_t:
@@ -132,7 +175,12 @@ jobs:
             Platform: x64
             Configuration: Release
             _HostPython: .\python
-            ExtraOptions: --disable-gil
+            ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+              ExtraOptions: '--disable-gil'
+            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+              ExtraOptions: '--disable-gil --experimental-jit-off'
+            ${{ else }}:
+              ExtraOptions: '--disable-gil --experimental-jit'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_amd64_t
             ${{ else }}:
@@ -143,7 +191,12 @@ jobs:
           Platform: x64
           Configuration: Debug
           _HostPython: .\python
-          ExtraOptions: --disable-gil
+          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+            ExtraOptions: '--disable-gil'
+          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+            ExtraOptions: '--disable-gil --experimental-jit-off'
+          ${{ else }}:
+            ExtraOptions: '--disable-gil --experimental-jit'
           Artifact: bin_amd64_td
         ${{ if or(ne(parameters.DoPGO, 'true'), ne(parameters.DoPGOARM64, 'true')) }}:
           arm64_t:
@@ -152,7 +205,12 @@ jobs:
             Platform: ARM64
             Configuration: Release
             _HostPython: python
-            ExtraOptions: --disable-gil
+            ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+              ExtraOptions: '--disable-gil'
+            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+              ExtraOptions: '--disable-gil --experimental-jit-off'
+            ${{ else }}:
+              ExtraOptions: '--disable-gil --experimental-jit'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64_t
             ${{ else }}:
@@ -163,7 +221,12 @@ jobs:
           Platform: ARM64
           Configuration: Debug
           _HostPython: python
-          ExtraOptions: --disable-gil
+          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+            ExtraOptions: '--disable-gil'
+          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+            ExtraOptions: '--disable-gil --experimental-jit-off'
+          ${{ else }}:
+            ExtraOptions: '--disable-gil --experimental-jit'
           Artifact: bin_arm64_td
 
   steps:
@@ -188,7 +251,12 @@ jobs:
           Platform: x64
           _HostPython: .\python
           PythonExePattern: python.exe
-          ExtraOptions: ''
+          ${{ if ne(parameters.DoJIT, 'true') }}:
+            ExtraOptions: ''
+          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+            ExtraOptions: '--experimental-jit-off'
+          ${{ else }}:
+            ExtraOptions: '--experimental-jit'
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_amd64
           ${{ else }}:
@@ -200,7 +268,12 @@ jobs:
             Platform: x64
             _HostPython: .\python
             PythonExePattern: python3*t.exe
-            ExtraOptions: --disable-gil
+            ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+              ExtraOptions: '--disable-gil'
+            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+              ExtraOptions: '--disable-gil --experimental-jit-off'
+            ${{ else }}:
+              ExtraOptions: '--disable-gil --experimental-jit'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_amd64_t
             ${{ else }}:
@@ -233,7 +306,12 @@ jobs:
           arm64:
             Name: arm64
             PythonExePattern: python.exe
-            ExtraOptions: ''
+            ${{ if ne(parameters.DoJIT, 'true') }}:
+              ExtraOptions: ''
+            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+              ExtraOptions: '--experimental-jit-off'
+            ${{ else }}:
+              ExtraOptions: '--experimental-jit'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64
             ${{ else }}:
@@ -242,7 +320,12 @@ jobs:
             arm64_t:
               Name: arm64_t
               PythonExePattern: python3*t.exe
-              ExtraOptions: --disable-gil
+              ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+                ExtraOptions: '--disable-gil'
+              ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+                ExtraOptions: '--disable-gil --experimental-jit-off'
+              ${{ else }}:
+                ExtraOptions: '--disable-gil --experimental-jit'
               ${{ if eq(parameters.ToBeSigned, 'true') }}:
                 Artifact: unsigned_arm64_t
               ${{ else }}:
@@ -313,7 +396,12 @@ jobs:
           arm64:
             Name: arm64
             PythonExePattern: python.exe
-            ExtraOptions: ''
+            ${{ if ne(parameters.DoJIT, 'true') }}:
+              ExtraOptions: ''
+            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+              ExtraOptions: '--experimental-jit-off'
+            ${{ else }}:
+              ExtraOptions: '--experimental-jit'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64
             ${{ else }}:
@@ -322,7 +410,12 @@ jobs:
             arm64_t:
               Name: arm64_t
               PythonExePattern: python3*t.exe
-              ExtraOptions: --disable-gil
+              ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
+                ExtraOptions: '--disable-gil'
+              ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
+                ExtraOptions: '--disable-gil --experimental-jit-off'
+              ${{ else }}:
+                ExtraOptions: '--disable-gil --experimental-jit'
               ${{ if eq(parameters.ToBeSigned, 'true') }}:
                 Artifact: unsigned_arm64_t
               ${{ else }}:

--- a/windows-release/stage-build.yml
+++ b/windows-release/stage-build.yml
@@ -5,7 +5,7 @@ parameters:
   DoFreethreaded: false
   ToBeSigned: false
   ExtraOptions: ''
-  ExtraOptionsFreethreaded: ''
+  ExtraOptionsFreethreaded: '--disable-gil'
 
 jobs:
 - job: Build_Docs

--- a/windows-release/stage-build.yml
+++ b/windows-release/stage-build.yml
@@ -4,8 +4,8 @@ parameters:
   DoPGOARM64: true
   DoFreethreaded: false
   ToBeSigned: false
-  JITOption: ''
-  JITOptionFreethreaded: ''
+  ExtraOptions: ''
+  ExtraOptionsFreethreaded: ''
 
 jobs:
 - job: Build_Docs
@@ -54,7 +54,7 @@ jobs:
         Platform: x86
         Configuration: Release
         _HostPython: .\python
-        ExtraOptions: ${{ parameters.JITOption }}
+        ExtraOptions: ${{ parameters.ExtraOptions }}
         ${{ if eq(parameters.ToBeSigned, 'true') }}:
           Artifact: unsigned_win32
         ${{ else }}:
@@ -65,7 +65,7 @@ jobs:
         Platform: x86
         Configuration: Debug
         _HostPython: .\python
-        ExtraOptions: ${{ parameters.JITOption }}
+        ExtraOptions: ${{ parameters.ExtraOptions }}
         Artifact: bin_win32_d
       ${{ if ne(parameters.DoPGO, 'true') }}:
         amd64:
@@ -74,7 +74,7 @@ jobs:
           Platform: x64
           Configuration: Release
           _HostPython: .\python
-          ExtraOptions: ${{ parameters.JITOption }}
+          ExtraOptions: ${{ parameters.ExtraOptions }}
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_amd64
           ${{ else }}:
@@ -85,7 +85,7 @@ jobs:
         Platform: x64
         Configuration: Debug
         _HostPython: .\python
-        ExtraOptions: ${{ parameters.JITOption }}
+        ExtraOptions: ${{ parameters.ExtraOptions }}
         Artifact: bin_amd64_d
       ${{ if or(ne(parameters.DoPGO, 'true'), ne(parameters.DoPGOARM64, 'true')) }}:
         arm64:
@@ -94,7 +94,7 @@ jobs:
           Platform: ARM64
           Configuration: Release
           _HostPython: python
-          ExtraOptions: ${{ parameters.JITOption }}
+          ExtraOptions: ${{ parameters.ExtraOptions }}
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_arm64
           ${{ else }}:
@@ -105,7 +105,7 @@ jobs:
         Platform: ARM64
         Configuration: Debug
         _HostPython: python
-        ExtraOptions: ${{ parameters.JITOption }}
+        ExtraOptions: ${{ parameters.ExtraOptions }}
         Artifact: bin_arm64_d
       ${{ if eq(parameters.DoFreethreaded, 'true') }}:
         win32_t:
@@ -114,7 +114,7 @@ jobs:
           Platform: x86
           Configuration: Release
           _HostPython: .\python
-          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+          ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_win32_t
           ${{ else }}:
@@ -125,7 +125,7 @@ jobs:
           Platform: x86
           Configuration: Debug
           _HostPython: .\python
-          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+          ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
           Artifact: bin_win32_td
         ${{ if ne(parameters.DoPGO, 'true') }}:
           amd64_t:
@@ -134,7 +134,7 @@ jobs:
             Platform: x64
             Configuration: Release
             _HostPython: .\python
-            ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+            ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_amd64_t
             ${{ else }}:
@@ -145,7 +145,7 @@ jobs:
           Platform: x64
           Configuration: Debug
           _HostPython: .\python
-          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+          ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
           Artifact: bin_amd64_td
         ${{ if or(ne(parameters.DoPGO, 'true'), ne(parameters.DoPGOARM64, 'true')) }}:
           arm64_t:
@@ -154,7 +154,7 @@ jobs:
             Platform: ARM64
             Configuration: Release
             _HostPython: python
-            ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+            ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64_t
             ${{ else }}:
@@ -165,7 +165,7 @@ jobs:
           Platform: ARM64
           Configuration: Debug
           _HostPython: python
-          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+          ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
           Artifact: bin_arm64_td
 
   steps:
@@ -190,7 +190,7 @@ jobs:
           Platform: x64
           _HostPython: .\python
           PythonExePattern: python.exe
-          ExtraOptions: ${{ parameters.JITOption }}
+          ExtraOptions: ${{ parameters.ExtraOptions }}
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_amd64
           ${{ else }}:
@@ -202,7 +202,7 @@ jobs:
             Platform: x64
             _HostPython: .\python
             PythonExePattern: python3*t.exe
-            ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+            ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_amd64_t
             ${{ else }}:
@@ -235,7 +235,7 @@ jobs:
           arm64:
             Name: arm64
             PythonExePattern: python.exe
-            ExtraOptions: ${{ parameters.JITOption }}
+            ExtraOptions: ${{ parameters.ExtraOptions }}
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64
             ${{ else }}:
@@ -244,7 +244,7 @@ jobs:
             arm64_t:
               Name: arm64_t
               PythonExePattern: python3*t.exe
-              ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+              ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
               ${{ if eq(parameters.ToBeSigned, 'true') }}:
                 Artifact: unsigned_arm64_t
               ${{ else }}:
@@ -315,7 +315,7 @@ jobs:
           arm64:
             Name: arm64
             PythonExePattern: python.exe
-            ExtraOptions: ${{ parameters.JITOption }}
+            ExtraOptions: ${{ parameters.ExtraOptions }}
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64
             ${{ else }}:
@@ -324,7 +324,7 @@ jobs:
             arm64_t:
               Name: arm64_t
               PythonExePattern: python3*t.exe
-              ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
+              ExtraOptions: ${{ parameters.ExtraOptionsFreethreaded }}
               ${{ if eq(parameters.ToBeSigned, 'true') }}:
                 Artifact: unsigned_arm64_t
               ${{ else }}:

--- a/windows-release/stage-build.yml
+++ b/windows-release/stage-build.yml
@@ -4,9 +4,8 @@ parameters:
   DoPGOARM64: true
   DoFreethreaded: false
   ToBeSigned: false
-  DoJIT: false
-  DoJITEnabled: false
-  DoJITFreethreaded: false
+  JITOption: ''
+  JITOptionFreethreaded: ''
 
 jobs:
 - job: Build_Docs
@@ -55,12 +54,7 @@ jobs:
         Platform: x86
         Configuration: Release
         _HostPython: .\python
-        ${{ if ne(parameters.DoJIT, 'true') }}:
-          ExtraOptions: ''
-        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-          ExtraOptions: '--experimental-jit-off'
-        ${{ else }}:
-          ExtraOptions: '--experimental-jit'
+        ExtraOptions: ${{ parameters.JITOption }}
         ${{ if eq(parameters.ToBeSigned, 'true') }}:
           Artifact: unsigned_win32
         ${{ else }}:
@@ -71,12 +65,7 @@ jobs:
         Platform: x86
         Configuration: Debug
         _HostPython: .\python
-        ${{ if ne(parameters.DoJIT, 'true') }}:
-          ExtraOptions: ''
-        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-          ExtraOptions: '--experimental-jit-off'
-        ${{ else }}:
-          ExtraOptions: '--experimental-jit'
+        ExtraOptions: ${{ parameters.JITOption }}
         Artifact: bin_win32_d
       ${{ if ne(parameters.DoPGO, 'true') }}:
         amd64:
@@ -85,12 +74,7 @@ jobs:
           Platform: x64
           Configuration: Release
           _HostPython: .\python
-          ${{ if ne(parameters.DoJIT, 'true') }}:
-            ExtraOptions: ''
-          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-            ExtraOptions: '--experimental-jit-off'
-          ${{ else }}:
-            ExtraOptions: '--experimental-jit'
+          ExtraOptions: ${{ parameters.JITOption }}
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_amd64
           ${{ else }}:
@@ -101,12 +85,7 @@ jobs:
         Platform: x64
         Configuration: Debug
         _HostPython: .\python
-        ${{ if ne(parameters.DoJIT, 'true') }}:
-          ExtraOptions: ''
-        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-          ExtraOptions: '--experimental-jit-off'
-        ${{ else }}:
-          ExtraOptions: '--experimental-jit'
+        ExtraOptions: ${{ parameters.JITOption }}
         Artifact: bin_amd64_d
       ${{ if or(ne(parameters.DoPGO, 'true'), ne(parameters.DoPGOARM64, 'true')) }}:
         arm64:
@@ -115,12 +94,7 @@ jobs:
           Platform: ARM64
           Configuration: Release
           _HostPython: python
-          ${{ if ne(parameters.DoJIT, 'true') }}:
-            ExtraOptions: ''
-          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-            ExtraOptions: '--experimental-jit-off'
-          ${{ else }}:
-            ExtraOptions: '--experimental-jit'
+          ExtraOptions: ${{ parameters.JITOption }}
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_arm64
           ${{ else }}:
@@ -131,12 +105,7 @@ jobs:
         Platform: ARM64
         Configuration: Debug
         _HostPython: python
-        ${{ if ne(parameters.DoJIT, 'true') }}:
-          ExtraOptions: ''
-        ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-          ExtraOptions: '--experimental-jit-off'
-        ${{ else }}:
-          ExtraOptions: '--experimental-jit'
+        ExtraOptions: ${{ parameters.JITOption }}
         Artifact: bin_arm64_d
       ${{ if eq(parameters.DoFreethreaded, 'true') }}:
         win32_t:
@@ -145,12 +114,7 @@ jobs:
           Platform: x86
           Configuration: Release
           _HostPython: .\python
-          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-            ExtraOptions: '--disable-gil'
-          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-            ExtraOptions: '--disable-gil --experimental-jit-off'
-          ${{ else }}:
-            ExtraOptions: '--disable-gil --experimental-jit'
+          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_win32_t
           ${{ else }}:
@@ -161,12 +125,7 @@ jobs:
           Platform: x86
           Configuration: Debug
           _HostPython: .\python
-          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-            ExtraOptions: '--disable-gil'
-          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-            ExtraOptions: '--disable-gil --experimental-jit-off'
-          ${{ else }}:
-            ExtraOptions: '--disable-gil --experimental-jit'
+          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
           Artifact: bin_win32_td
         ${{ if ne(parameters.DoPGO, 'true') }}:
           amd64_t:
@@ -175,12 +134,7 @@ jobs:
             Platform: x64
             Configuration: Release
             _HostPython: .\python
-            ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-              ExtraOptions: '--disable-gil'
-            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-              ExtraOptions: '--disable-gil --experimental-jit-off'
-            ${{ else }}:
-              ExtraOptions: '--disable-gil --experimental-jit'
+            ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_amd64_t
             ${{ else }}:
@@ -191,12 +145,7 @@ jobs:
           Platform: x64
           Configuration: Debug
           _HostPython: .\python
-          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-            ExtraOptions: '--disable-gil'
-          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-            ExtraOptions: '--disable-gil --experimental-jit-off'
-          ${{ else }}:
-            ExtraOptions: '--disable-gil --experimental-jit'
+          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
           Artifact: bin_amd64_td
         ${{ if or(ne(parameters.DoPGO, 'true'), ne(parameters.DoPGOARM64, 'true')) }}:
           arm64_t:
@@ -205,12 +154,7 @@ jobs:
             Platform: ARM64
             Configuration: Release
             _HostPython: python
-            ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-              ExtraOptions: '--disable-gil'
-            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-              ExtraOptions: '--disable-gil --experimental-jit-off'
-            ${{ else }}:
-              ExtraOptions: '--disable-gil --experimental-jit'
+            ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64_t
             ${{ else }}:
@@ -221,12 +165,7 @@ jobs:
           Platform: ARM64
           Configuration: Debug
           _HostPython: python
-          ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-            ExtraOptions: '--disable-gil'
-          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-            ExtraOptions: '--disable-gil --experimental-jit-off'
-          ${{ else }}:
-            ExtraOptions: '--disable-gil --experimental-jit'
+          ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
           Artifact: bin_arm64_td
 
   steps:
@@ -251,12 +190,7 @@ jobs:
           Platform: x64
           _HostPython: .\python
           PythonExePattern: python.exe
-          ${{ if ne(parameters.DoJIT, 'true') }}:
-            ExtraOptions: ''
-          ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-            ExtraOptions: '--experimental-jit-off'
-          ${{ else }}:
-            ExtraOptions: '--experimental-jit'
+          ExtraOptions: ${{ parameters.JITOption }}
           ${{ if eq(parameters.ToBeSigned, 'true') }}:
             Artifact: unsigned_amd64
           ${{ else }}:
@@ -268,12 +202,7 @@ jobs:
             Platform: x64
             _HostPython: .\python
             PythonExePattern: python3*t.exe
-            ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-              ExtraOptions: '--disable-gil'
-            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-              ExtraOptions: '--disable-gil --experimental-jit-off'
-            ${{ else }}:
-              ExtraOptions: '--disable-gil --experimental-jit'
+            ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_amd64_t
             ${{ else }}:
@@ -306,12 +235,7 @@ jobs:
           arm64:
             Name: arm64
             PythonExePattern: python.exe
-            ${{ if ne(parameters.DoJIT, 'true') }}:
-              ExtraOptions: ''
-            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-              ExtraOptions: '--experimental-jit-off'
-            ${{ else }}:
-              ExtraOptions: '--experimental-jit'
+            ExtraOptions: ${{ parameters.JITOption }}
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64
             ${{ else }}:
@@ -320,12 +244,7 @@ jobs:
             arm64_t:
               Name: arm64_t
               PythonExePattern: python3*t.exe
-              ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-                ExtraOptions: '--disable-gil'
-              ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-                ExtraOptions: '--disable-gil --experimental-jit-off'
-              ${{ else }}:
-                ExtraOptions: '--disable-gil --experimental-jit'
+              ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
               ${{ if eq(parameters.ToBeSigned, 'true') }}:
                 Artifact: unsigned_arm64_t
               ${{ else }}:
@@ -396,12 +315,7 @@ jobs:
           arm64:
             Name: arm64
             PythonExePattern: python.exe
-            ${{ if ne(parameters.DoJIT, 'true') }}:
-              ExtraOptions: ''
-            ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-              ExtraOptions: '--experimental-jit-off'
-            ${{ else }}:
-              ExtraOptions: '--experimental-jit'
+            ExtraOptions: ${{ parameters.JITOption }}
             ${{ if eq(parameters.ToBeSigned, 'true') }}:
               Artifact: unsigned_arm64
             ${{ else }}:
@@ -410,12 +324,7 @@ jobs:
             arm64_t:
               Name: arm64_t
               PythonExePattern: python3*t.exe
-              ${{ if or(ne(parameters.DoJIT, 'true'), ne(parameters.DoJITFreethreaded, 'true')) }}:
-                ExtraOptions: '--disable-gil'
-              ${{ elseif ne(parameters.DoJITEnabled, 'true') }}:
-                ExtraOptions: '--disable-gil --experimental-jit-off'
-              ${{ else }}:
-                ExtraOptions: '--disable-gil --experimental-jit'
+              ExtraOptions: '--disable-gil ${{ parameters.JITOptionFreethreaded }}'
               ${{ if eq(parameters.ToBeSigned, 'true') }}:
                 Artifact: unsigned_arm64_t
               ${{ else }}:


### PR DESCRIPTION
I'm not sure how to test this, or even if this is the right approach, so I'd appreciate @zooba's eyes on this. Hopefully I'm on the right track, though.

I went ahead and "future-proofed" this by adding additional options for enabling the JIT by default (not desired until 3.15 at the earliest), and also building it on free-threaded builds (not possible until 3.15 at the earliest). These options can be dropped though, if they add too much noise.