### PR TITLE
Add MIT licence

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2008 Benjamin Peterson and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
We don't have a licence is this repo, which means some people cannot contribute.

I suggest we add MIT licence, which was recently used for buildmaster-config: https://github.com/python/buildmaster-config/blob/main/LICENSE.txt

To continue, please could everyone listed below leave a comment to confirm you are happy to licence your [past contributions](https://github.com/python/release-tools/graphs/contributors) to this repo under MIT?

* [ ] @AA-Turner
* [x] @AlexWaygood
* [ ] @ambv
* [ ] @benjaminp
* [x] @berkerpeksag
* [ ] @birkenfeld
* [x] @brandtbucher
* [x] @carljm
* [x] @di
* [x] @Eclips4
* [x] @encukou
* [x] @ezio-melotti
* [x] @hugovk
* [x] @ice-tong
* [x] @JelleZijlstra
* [ ] @larryhastings
* [x] @ned-deily
* [ ] @oliver-rew
* [ ] @pablogsal
* [ ] @serhiy-storchaka
* [x] @sethmlarson
* [x] @vstinner
* [x] @Wulian233
* [x] @Yhg1s
* [ ] @zooba
* [x] @zware
