### PR TITLE
Publish windows-VER.json to downloads list

### DIFF
--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -104,7 +104,15 @@ def get_file_descriptions(
     return [
         (rx(r"\.tgz$"), ("Gzipped source tarball", 3, False, "")),
         (rx(r"\.tar\.xz$"), ("XZ compressed source tarball", 3, True, "")),
-        (rx(r"-webinstall\.exe$"), ("", 0, False, "")),
+        (
+            rx(r"windows-.+\.json"),
+            (
+                "Windows release manifest",
+                1,
+                False,
+                f"Use 'py install {v[0]}.{v[1]}' to install",
+            ),
+        ),
         (
             rx(r"-embed-amd64\.zip$"),
             ("Windows embeddable package (64-bit)", 1, False, ""),

--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -110,7 +110,7 @@ def get_file_descriptions(
                 "Windows release manifest",
                 1,
                 False,
-                f"Use 'py install {v[0]}.{v[1]}' to install",
+                f"Install with 'py install {v[0]}.{v[1]}'",
             ),
         ),
         (


### PR DESCRIPTION
Also removes the web installers, which we haven't published in a long time now.