### PR TITLE
Add PSF licence

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,46 @@
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2008 Python Software Foundation; All Rights Reserved"
+are retained in Python alone or in any derivative version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.


### PR DESCRIPTION
We don't have a licence is this repo, which means some people cannot contribute.

This PR adds the Python Software Foundation licence, text taken from https://github.com/python/cpython/blob/35f47d05893e012e9f2b145b934c1d8c61d2bb7d/LICENSE#L73-L118 with the year set to 2008, the first contribution in this repo.

We've had the the CLA bot enabled since at least 18th July 2023 (https://github.com/python/release-tools/pull/51#issuecomment-1638908462), so all contributions after this will have signed the CLA.

Limiting to before this date at https://github.com/python/release-tools/graphs/contributors gives the following contributors.

To continue, please could everyone listed below leave a comment to confirm you are happy to licence your [past contributions](https://github.com/python/release-tools/graphs/contributors) to this repo under the PSF licence?

* [x] @ambv
* [x] @benjaminp
* [x] @berkerpeksag
* [x] @birkenfeld
* [x] carljm: [#246 (comment)](https://github.com/python/release-tools/pull/246#issuecomment-2863961446)
* [x] @di
* [x] @ezio-melotti
* [x] @larryhastings
* [x] @ned-deily
* [x] @pablogsal
* [x] @serhiy-storchaka
* [x] @vstinner
* [x] Yhg1s: [#246 (comment)](https://github.com/python/release-tools/pull/246#issuecomment-2863906673)
* [x] @zooba

Carl and Thomas already checked off because they already approved this or any licence in the previous issue.

Thanks again!
