### PR TITLE
First beta: improve `SOURCE_URI` error message

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -533,7 +533,10 @@ def check_pyspecific(db: ReleaseShelf) -> None:
         f"SOURCE_URI = 'https://github.com/python/cpython/tree/{expected_branch}/%s'"
     )
     if expected != line.strip():
-        raise ReleaseException("SOURCE_URI is incorrect")
+        raise ReleaseException(
+            f"SOURCE_URI is incorrect, expected: {expected}, got: {line.strip()} "
+            "(it needs changing before beta 1)"
+        )
 
 
 def bump_version(db: ReleaseShelf) -> None:

--- a/run_release.py
+++ b/run_release.py
@@ -534,8 +534,9 @@ def check_pyspecific(db: ReleaseShelf) -> None:
     )
     if expected != line.strip():
         raise ReleaseException(
-            f"SOURCE_URI is incorrect, expected: {expected}, got: {line.strip()} "
-            "(it needs changing before beta 1)"
+            f"SOURCE_URI is incorrect (it needs changing before beta 1):\n"
+            f"expected: {expected}\n"
+            f"got     : {line.strip()}"
         )
 
 


### PR DESCRIPTION
This will help future me for 3.15.0b1.

---

Note: for 3.14.0b1, I needed to change this to `.../3.14/...` in `main` before starting the release.

And then after the release, 3.14 was in the new `3.14` branch and 3.15 had become `main`, so needed to revert it back to `.../main/...` on `main`.
