### PR TITLE
Bump rfc3161-client (and sigstore and tuf)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -797,20 +797,19 @@ requests==2.32.4 \
     # via
     #   id
     #   sigstore
-    #   tuf
-rfc3161-client==0.1.2 \
-    --hash=sha256:1e01498007779bdef720422f4481d87e340b875b851f909434822b604c856682 \
-    --hash=sha256:471304f8a94f31b1e0f45aa4138bb50cf2dc38808e96465bafad9e128c75ea7b \
-    --hash=sha256:590aa4a04e445589ffded1fe91782efe07d71f6fb75ff54d768a120373c7c1ff \
-    --hash=sha256:5bc220bd7f1525898cd33b6d8f1508f9ba080a3008ba9d1416ab5c0a46df4326 \
-    --hash=sha256:68be67081aefa787f17c11e75ff625d8b4e8245829822da5e5b240d7ef415f61 \
-    --hash=sha256:741180cc1e5e093fa06c7abe71caac672b08fc9b94d2f9644fa8dd5aa48b646d \
-    --hash=sha256:92e24bd34c2567712060cf7701ec9580572b35300eec3b57f886d8dcbf036dd8 \
-    --hash=sha256:9f7e8b2bf955ab0e3b1f1ac2c2a1f9dbe6657cd93981d890aae5748998cd275a \
-    --hash=sha256:b6b6d33c21ed3960b29997000837bf5588d01e7c85bf74a06b653e3b8a679cc4 \
-    --hash=sha256:be5960c3fbd560067b6e7e57c0496c1097c689f56d0f1237acdb854ad2ee32c0 \
-    --hash=sha256:c45143a0ed73845ace404c1c21d5de6345265988a247193f96db4ef81577c07b \
-    --hash=sha256:e81dbd93d1e2180603d3dbd88635b6897c415a1de960818a23e14293fef033d5
+rfc3161-client==1.0.3 \
+    --hash=sha256:0d40bb252d1a0714f4faa6b538be0bcbe9d13c6a7a37188b26f9f23d34aad7a3 \
+    --hash=sha256:39e188281bc04378130ed52b1b00ee330570f04f0000cc60a0a534803f349482 \
+    --hash=sha256:649037dbade2e78bdc1e8d7d917b04f27c245e0d758ab713f2ddeeec0fc6dd52 \
+    --hash=sha256:863d97877c3aa7e42682f70da0f3009618bc1e2aa0a7353133b94dd649d3a602 \
+    --hash=sha256:9d4d628e00fee72f07bdc779ce75160036c8cb318cac5336cd12692e2d7153e8 \
+    --hash=sha256:a231b2d3430216491a4dac0cb04afdad0398bf5ded39138938b6002734abf2b4 \
+    --hash=sha256:b3f513adc5d4c1c59aed1f5f89fbe2e560410f461ae163fdca8c130939df79d6 \
+    --hash=sha256:c6743aa339c07772a53ffb1accc7def78c11d8ebba57c6d25329c1d412dde4dd \
+    --hash=sha256:e5eeb73862b28e5aacc2951c0aec72ecff5209925a4c5be2753cd30f13c39ae5 \
+    --hash=sha256:ea49605cf10558145b075979d8bfc8bff685c44815bf8b66fd580ced642216c9 \
+    --hash=sha256:f2a925e668b7637c0aecd416dd060ec9579a5edd62502bb88efa981791419a44 \
+    --hash=sha256:f76bdf2a9f80ea97a99324fa74695621fddc0e6f5d4a4a4e0ca30e822a37e534
     # via sigstore
 rfc8785==0.1.4 \
     --hash=sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48
@@ -821,8 +820,8 @@ rich==13.9.4 \
 securesystemslib==1.2.0 \
     --hash=sha256:fa63abcb1cf4dba4f2df964f623baa45bc39029980d7a0a2119d90731942afc6
     # via tuf
-sigstore==3.6.1 \
-    --hash=sha256:b568b16322222e834940acabdc84fbb16c8780874c3c21c6c8dde928dae0f881
+sigstore==3.6.4 \
+    --hash=sha256:d5678a7f4b78b084eb2c1a9eab31af81e6daf1f949abc3b7539a96900220d0d6
     # via -r requirements.in
 sigstore-protobuf-specs==0.3.2 \
     --hash=sha256:50c99fa6747a3a9c5c562a43602cf76df0b199af28f0e9d4319b6775630425ea
@@ -833,8 +832,8 @@ sigstore-rekor-types==0.0.18 \
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
     # via python-dateutil
-tuf==5.1.0 \
-    --hash=sha256:6494848d2720ced600e0d7ee23b4986623ddad1148ad8e54ffe308db18b762fe
+tuf==6.0.0 \
+    --hash=sha256:458f663a233d95cc76dde0e1a3d01796516a05ce2781fefafebe037f7729601a
     # via sigstore
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d
@@ -844,7 +843,9 @@ typing-extensions==4.12.2 \
     #   pyopenssl
 urllib3==2.5.0 \
     --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
-    # via requests
+    # via
+    #   requests
+    #   tuf
 yarl==1.18.3 \
     --hash=sha256:00e5a1fea0fd4f5bfa7440a47eff01d9822a65b4488f7cff83155a0f31a2ecba \
     --hash=sha256:02ddb6756f8f4517a2d5e99d8b2f272488e18dd0bfbc802f31c16c6c20f22193 \


### PR DESCRIPTION
Fixes a security alert:

* :lock: https://github.com/python/release-tools/security/dependabot/33

Updated with this command, needed to bump `sigstore` and `tuf` as well:
```sh
pip-compile --generate-hashes --output-file=requirements.txt requirements.in --upgrade-package rfc3161-client --upgrade-package sigstore --upgrade-package tuf
```
