### PR TITLE
Don't show API key in release summary

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -252,7 +252,9 @@ class ReleaseDriver:
         print(f"- Normalized release tag: {release_tag.normalized()}")
         print(f"- Git repo: {self.db['git_repo']}")
         print(f"- SSH username: {self.db['ssh_user']}")
-        print(f"- python.org API key: {self.db['auth_info']}")
+        user, key = self.db["auth_info"].split(":")
+        masked = "*" * (len(key) - 4) + key[-4:]
+        print(f"- python.org API key: {user}:{masked}")
         print(f"- Sign with GPG: {self.db['sign_gpg']}")
         print()
 

--- a/run_release.py
+++ b/run_release.py
@@ -252,9 +252,6 @@ class ReleaseDriver:
         print(f"- Normalized release tag: {release_tag.normalized()}")
         print(f"- Git repo: {self.db['git_repo']}")
         print(f"- SSH username: {self.db['ssh_user']}")
-        user, key = self.db["auth_info"].split(":")
-        masked = "*" * (len(key) - 4) + key[-4:]
-        print(f"- python.org API key: {user}:{masked}")
         print(f"- Sign with GPG: {self.db['sign_gpg']}")
         print()
 


### PR DESCRIPTION
Right now, `run_release.py` prints a summary at the start, including the API key:

```console
❯ .venv/bin/python run_release.py --repository ../cpython --ssh-user me --release 3.14.0a0
Release data:
- Branch: main
- Release tag: 3.14.0a0
- Normalized release tag: 3.14.0
- Git repo: ../cpython
- SSH username: me
- python.org API key: me:123456789012345678901234567890123456789
- Sign with GPG: False
```

~Let's mask it:~

```console
❯ .venv/bin/python run_release.py --repository ../cpython --ssh-user me --release 3.14.0a0
Release data:
- Branch: main
- Release tag: 3.14.0a0
- Normalized release tag: 3.14.0
- Git repo: ../cpython
- SSH username: me
- python.org API key: me:************************************789
- Sign with GPG: False
```

Let's not show it:

```console
❯ .venv/bin/python run_release.py --repository ../cpython --ssh-user me --release 3.14.0a0
Release data:
- Branch: main
- Release tag: 3.14.0a0
- Normalized release tag: 3.14.0
- Git repo: ../cpython
- SSH username: me
- Sign with GPG: False
```

