### PR TITLE
Update dependencies for typing and wheels

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.12.14
-alive_progress  # untyped :(
+alive_progress>=3.3.0
 mypy==1.16.1
 pyfakefs
 pytest

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,7 @@
 --only-binary :all:
-# grapheme doesn't have a binary release, but alive_progress
-# requires grapheme==0.6.0.
---no-binary grapheme
 
 paramiko
-alive_progress
+alive_progress>=3.3.0
 python-gnupg
 aiohttp
 blurb>=1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 #    pip-compile --generate-hashes --output-file=requirements.txt requirements.in
 #
 --only-binary :all:
---no-binary grapheme
 
 about-time==4.2.1 \
     --hash=sha256:8bbf4c75fe13cbd3d72f49a03b02c5c7dca32169b6d49117c257e7eb3eaee341
@@ -93,8 +92,8 @@ aiohttp==3.11.11 \
 aiosignal==1.3.2 \
     --hash=sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5
     # via aiohttp
-alive-progress==3.2.0 \
-    --hash=sha256:0677929f8d3202572e9d142f08170b34dbbe256cc6d2afbf75ef187c7da964a8
+alive-progress==3.3.0 \
+    --hash=sha256:63dd33bb94cde15ad9e5b666dbba8fedf71b72a4935d6fb9a92931e69402c9ff
     # via -r requirements.in
 annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
@@ -437,8 +436,8 @@ frozenlist==1.5.0 \
     # via
     #   aiohttp
     #   aiosignal
-grapheme==0.6.0 \
-    --hash=sha256:44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca
+graphemeu==0.7.2 \
+    --hash=sha256:1444520f6899fd30114fc2a39f297d86d10fa0f23bf7579f772f8bc7efaa2542
     # via alive-progress
 grpclib==0.4.8 \
     --hash=sha256:a5047733a7acc1c1cee6abf3c841c7c6fab67d2844a45a853b113fa2e6cd2654

--- a/run_release.py
+++ b/run_release.py
@@ -30,7 +30,7 @@ import aiohttp
 import gnupg  # type: ignore[import-untyped]
 import paramiko
 import sigstore.oidc
-from alive_progress import alive_bar  # type: ignore[import-untyped]
+from alive_progress import alive_bar
 
 import release as release_mod
 import sbom


### PR DESCRIPTION
The new alive-progress release:

https://pypi.org/project/alive-progress/3.3.0/

Is both typed:

* https://github.com/rsalmei/alive-progress/pull/294

And has replaced the unmaintained grapheme (with no wheels) with the maintained graphemeu (with a wheel):

* https://github.com/rsalmei/alive-progress/pull/285

---

This means we won't run into the pip-tools bug that re-ordered `-only-binary :all:` and `--no-binary grapheme`.

And our dependencies beat the race against a new pip-tools release by a matter of days :)

* https://github.com/jazzband/pip-tools/pull/2082
* https://github.com/jazzband/pip-tools/issues/2112