### PR TITLE
Replace "texlive-full" with "texlive-latex-{recommended,extra}"

### DIFF
--- a/.github/workflows/source-and-docs-release.yml
+++ b/.github/workflows/source-and-docs-release.yml
@@ -141,7 +141,7 @@ jobs:
           python -m pip install -r Doc/requirements.txt
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
-            fonts-freefont-otf  \
+            fonts-freefont-otf \
             latexmk \
             texinfo \
             texlive-fonts-extra \


### PR DESCRIPTION
cc @hugovk 

[texlive-full](https://packages.ubuntu.com/noble/texlive-full) requires lots of packages we don't need. [Sphinx suggests](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder) `texlive-latex-{recommended,extra}`.

A