### PR TITLE
Python 3.14 universal2 is for macOS 11 and later

### DIFF
--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -81,7 +81,6 @@ google_oidc_provider = "https://accounts.google.com"
 
 # Update this list when new release managers are added.
 release_to_sigstore_identity_and_oidc_issuer = {
-    "3.8": ("lukasz@langa.pl", github_oidc_provider),
     "3.9": ("lukasz@langa.pl", github_oidc_provider),
     "3.10": ("pablogsal@python.org", google_oidc_provider),
     "3.11": ("pablogsal@python.org", google_oidc_provider),
@@ -134,13 +133,13 @@ def get_file_descriptions(
         ),
         (
             rx(r"-amd64\.exe$"),
-            ("Windows installer (64-bit)", "windows", v >= (3, 9), "Recommended"),
+            ("Windows installer (64-bit)", "windows", True, "Recommended"),
         ),
         (
             rx(r"-embed-win32\.zip$"),
             ("Windows embeddable package (32-bit)", "windows", False, ""),
         ),
-        (rx(r"\.exe$"), ("Windows installer (32-bit)", "windows", v < (3, 9), "")),
+        (rx(r"\.exe$"), ("Windows installer (32-bit)", "windows", False, "")),
         (
             rx(r"-macosx10\.5(_rev\d)?\.(dm|pk)g$"),
             (

--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -91,10 +91,19 @@ release_to_sigstore_identity_and_oidc_issuer = {
 }
 
 
+def macos_universal2_description(version: tuple[int, int, int]) -> str:
+    if version >= (3, 14):
+        return "for macOS 11 and later"
+    elif version >= (3, 12, 6):
+        return "for macOS 10.13 and later"
+    else:
+        return "for macOS 10.9 and later"
+
+
 def get_file_descriptions(
     release: str,
 ) -> list[tuple[re.Pattern[str], tuple[str, str, bool, str]]]:
-    v = minor_version_tuple(release)
+    v = base_version_tuple(release)
     rx = re.compile
     # value is (file "name", OS slug, download button, file "description").
     # OS=None means no ReleaseFile object. Only one matching *file* (not regex)
@@ -165,7 +174,7 @@ def get_file_descriptions(
                 "macOS 64-bit universal2 installer",
                 "macos",
                 True,
-                f"for macOS {'10.13' if v >= (3, 12, 6) else '10.9'} and later",
+                macos_universal2_description(v),
             ),
         ),
         (
@@ -209,6 +218,12 @@ def base_version(release: str) -> str:
     m = tag_cre.match(release)
     assert m is not None, f"Invalid release: {release}"
     return ".".join(m.groups()[:3])
+
+
+def base_version_tuple(release: str) -> tuple[int, int, int]:
+    m = tag_cre.match(release)
+    assert m is not None, f"Invalid release: {release}"
+    return int(m.groups()[0]), int(m.groups()[1]), int(m.groups()[2])
 
 
 def minor_version(release: str) -> str:

--- a/tests/test_add_to_pydotorg.py
+++ b/tests/test_add_to_pydotorg.py
@@ -93,6 +93,19 @@ def test_base_version(release: str, expected: str) -> None:
 @pytest.mark.parametrize(
     ["release", "expected"],
     [
+        ("3.9.0a0", (3, 9, 0)),
+        ("3.10.0b3", (3, 10, 0)),
+        ("3.11.0rc2", (3, 11, 0)),
+        ("3.12.15", (3, 12, 15)),
+    ],
+)
+def test_base_version_tuple(release: str, expected: tuple[int, int, int]) -> None:
+    assert add_to_pydotorg.base_version_tuple(release) == expected
+
+
+@pytest.mark.parametrize(
+    ["release", "expected"],
+    [
         ("3.9.0a0", "3.9"),
         ("3.10.0b3", "3.10"),
         ("3.11.0rc2", "3.11"),
@@ -114,6 +127,25 @@ def test_minor_version(release: str, expected: str) -> None:
 )
 def test_minor_version_tuple(release: str, expected: tuple[int, int]) -> None:
     assert add_to_pydotorg.minor_version_tuple(release) == expected
+
+
+@pytest.mark.parametrize(
+    ["release", "expected"],
+    [
+        ((3, 9, 0), "for macOS 10.9 and later"),
+        ((3, 10, 0), "for macOS 10.9 and later"),
+        ((3, 11, 0), "for macOS 10.9 and later"),
+        ((3, 12, 0), "for macOS 10.9 and later"),
+        ((3, 12, 5), "for macOS 10.9 and later"),
+        ((3, 12, 6), "for macOS 10.13 and later"),
+        ((3, 13, 0), "for macOS 10.13 and later"),
+        ((3, 14, 0), "for macOS 11 and later"),
+    ],
+)
+def test_macos_universal2_description(
+    release: tuple[int, int, int], expected: str
+) -> None:
+    assert add_to_pydotorg.macos_universal2_description(release) == expected
 
 
 def test_list_files(fs: FakeFilesystem) -> None:
@@ -185,7 +217,7 @@ def test_list_files(fs: FakeFilesystem) -> None:
             "macOS 64-bit universal2 installer",
             "macos",
             True,
-            "for macOS 10.13 and later",
+            "for macOS 11 and later",
         ),
         (
             "python-3.14.0b3-x86_64-linux-android.tar.gz",


### PR DESCRIPTION
For https://github.com/python/cpython/issues/137749.

The Python 3.14 installer is for macOS 11 and later.

---

I also added tests, which found an existing bug (tests find bugs? 🤯).

The previous `f"for macOS {'10.13' if v >= (3, 12, 6) else '10.9'} and later"` was giving us "for macOS 10.9 and later" for 3.12.10 instead of "for macOS 10.13 and later.

See: https://www.python.org/downloads/release/python-31210/

This is because we were `minor_version_tuple` only gives us `(x, y)`, not `(x, y, z)`:
```pycon
>>> v = >>> v = minor_version_tuple("3.12.10")
>>> v
(3, 12)
>>> f"for macOS {'10.13' if v >= (3, 12, 6) else '10.9'} and later"
'for macOS 10.9 and later'("3.12.10")
>>> v
(3, 12)
>>> f"for macOS {'10.13' if v >= (3, 12, 6) else '10.9'} and later"
'for macOS 10.9 and later'
```

Instead, let's add `base_version_tuple`:

```pycon
>>> v = base_version_tuple("3.12.10")
>>> v
(3, 12, 10)
>>> f"for macOS {'10.13' if v >= (3, 12, 6) else '10.9'} and later"
'for macOS 10.13 and later'
```

---

Finally, remove some redundant code for EOL Python 3.8.