### PR TITLE
Build Android artifacts with a reusable workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,9 +41,9 @@ permissions: {}
 
 # Set from inputs for workflow_dispatch, or set defaults to test push/PR events
 env:
-  GIT_REMOTE: ${{ github.event.inputs.git_remote || 'python' }}
-  GIT_COMMIT: ${{ github.event.inputs.git_commit || '4f8bb3947cfbc20f970ff9d9531e1132a9e95396' }}
-  CPYTHON_RELEASE: ${{ github.event.inputs.cpython_release || '3.13.2' }}
+  GIT_REMOTE: ${{ github.event.inputs.git_remote || 'mhsmith' }}
+  GIT_COMMIT: ${{ github.event.inputs.git_commit || '7e87375eeff06e03a66209e506ce83c3f70ec57f' }}
+  CPYTHON_RELEASE: ${{ github.event.inputs.cpython_release || '3.15.0b991' }}
 
 jobs:
   verify-input:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
+      checkout-ref: v${{ env.CPYTHON_RELEASE }}
+      checkout-repository: ${{ env.GIT_REMOTE }}/cpython
       build-docs: ${{ steps.select-jobs.outputs.docs }}
       build-android: ${{ steps.select-jobs.outputs.android }}
     steps:
@@ -204,7 +206,8 @@ jobs:
           ./bin/python3 -m test -uall
 
   build-android:
-    name: build-android (${{ matrix.arch }})
+    # ${{ '' } is a hack to nest jobs under the same sidebar category.
+    name: Android${{ '' }}  # zizmor: ignore[obfuscation]
     needs:
       - verify-input
     if: fromJSON(needs.verify-input.outputs.build-android)
@@ -217,23 +220,13 @@ jobs:
           - arch: x86_64
             runs-on: ubuntu-24.04
 
-    runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 60
-    env:
-      triplet: ${{ matrix.arch }}-linux-android
-    steps:
-      - name: "Checkout ${{ env.GIT_REMOTE }}/cpython"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-          repository: "${{ env.GIT_REMOTE }}/cpython"
-          ref: "v${{ env.CPYTHON_RELEASE }}"
-
-      - name: Build and test
-        run: ./Android/android.py ci "$triplet"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.triplet }}
-          path: cross-build/${{ env.triplet }}/dist/*
-          if-no-files-found: error
+    # FIXME: point to python/cpython once tested
+    uses: webknjaz/cpython/.github/workflows/reusable-android.yml@29fe94de87e4d970127c6ad79928e79302a214a3
+    with:
+      arch: ${{ matrix.arch }}
+      check-name: ${{ matrix.arch }}
+      checkout-ref: ${{ needs.verify-input.outputs.checkout-ref }}
+      checkout-repository: ${{ needs.verify-input.outputs.checkout-repository }}
+      runner-vm-os: ${{ matrix.runs-on }}
+      store-built-artifacts: true
+      timeout-minutes: 60


### PR DESCRIPTION
This is a follow up for #265 that added initial implementation with
copy-pasted steps.