### PR TITLE
Move removals above deprecations in What's New template

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -157,6 +157,7 @@ module_name
 -----------
 
 * TODO
+.. Add removals above alphabetically, not here at the end.
 
 
 Deprecated


### PR DESCRIPTION
Removals are generally more important.

To match how we did it in 3.13 https://docs.python.org/dev/whatsnew/3.13.html and will do for 3.14: https://github.com/python/cpython/pull/137794.

cc @AA-Turner 