### PR TITLE
Test 3.14.0rc2 by default so Android is tested

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,8 +42,8 @@ permissions: {}
 # Set from inputs for workflow_dispatch, or set defaults to test push/PR events
 env:
   GIT_REMOTE: ${{ github.event.inputs.git_remote || 'python' }}
-  GIT_COMMIT: ${{ github.event.inputs.git_commit || '4f8bb3947cfbc20f970ff9d9531e1132a9e95396' }}
-  CPYTHON_RELEASE: ${{ github.event.inputs.cpython_release || '3.13.2' }}
+  GIT_COMMIT: ${{ github.event.inputs.git_commit || '31967d8de3d27889dd1819b8dccc2bdc17c030c1' }}
+  CPYTHON_RELEASE: ${{ github.event.inputs.cpython_release || '3.14.0rc2' }}
 
 jobs:
   verify-input:


### PR DESCRIPTION
Re: https://github.com/python/cpython/issues/137242

Use 3.14.0rc2 as the default for the CI, as that release includes the Android tooling and it'll trigger the Android tests here.

Before:

<img width="822" height="279" alt="image" src="https://github.com/user-attachments/assets/e698d602-7f7f-40d1-8d55-078718d9e6a4" />

https://github.com/python/release-tools/actions/runs/16990557014

After:

<img width="829" height="295" alt="image" src="https://github.com/user-attachments/assets/8433e521-fea5-404a-aafc-aa3ad9df24b4" />

https://github.com/hugovk/release-tools/actions/runs/16991450836