### PR TITLE
Select all artifact jobs when testing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,6 +61,14 @@ jobs:
           echo "git_commit: $GIT_COMMIT"
           echo "cpython_release: $CPYTHON_RELEASE"
 
+          {
+            echo "| Variable        | Value                |"
+            echo "| --------------- | -------------------- |"
+            echo "| git_remote      | \`$GIT_REMOTE\`      |"
+            echo "| git_commit      | \`$GIT_COMMIT\`      |"
+            echo "| cpython_release | \`$CPYTHON_RELEASE\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: "Checkout python/release-tools"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -89,7 +97,20 @@ jobs:
       - name: "Select jobs"
         id: select-jobs
         run: |
-          ./select_jobs.py "$CPYTHON_RELEASE" | tee -a "$GITHUB_OUTPUT"
+          test_flag=""
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            test_flag="--test"
+          fi
+          output=$(./select_jobs.py $test_flag "$CPYTHON_RELEASE")
+          echo "$output" | tee -a "$GITHUB_OUTPUT"
+
+          {
+            echo "| Job     | Enabled |"
+            echo "| ------- | ------- |"
+            echo "$output" | while IFS='=' read -r key value; do
+              echo "| $key | $value |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build-source:
     runs-on: ubuntu-24.04

--- a/select_jobs.py
+++ b/select_jobs.py
@@ -12,8 +12,21 @@ def output(key: str, value: bool) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("version", type=Tag)
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Enable all jobs for testing",
+    )
     args = parser.parse_args()
     version = args.version
+
+    if args.test:
+        # When testing the workflow itself (push/PR),
+        # enable all jobs for full coverage.
+        output("docs", True)
+        output("android", True)
+        output("ios", True)
+        return
 
     # Docs are only built for stable releases or release candidates.
     output("docs", version.level in ["rc", "f"])

--- a/tests/test_select_jobs.py
+++ b/tests/test_select_jobs.py
@@ -38,3 +38,28 @@ def test_select_jobs(
             ios={ios}
         """
     )
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "3.13.0a1",
+        "3.13.0",
+        "3.14.0b2",
+        "3.15.0a1",
+    ],
+)
+def test_select_jobs_test_mode(
+    version: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["select_jobs.py", "--test", version])
+    select_jobs.main()
+    assert capsys.readouterr().out == dedent(
+        """\
+            docs=true
+            android=true
+            ios=true
+        """
+    )


### PR DESCRIPTION
The "build artifacts" workflow can triggered in three ways:

* `workflow_dispatch`: when make a real release. The actual release Git remote/commit/version are passed in as inputs.
* `push` and `pull_request`: when opening PRs to test we've not broken anything. A default remote/commit/version is used.

This is a follow on from https://github.com/python/release-tools/pull/365, which changed the default for testing from 3.14 to 3.15, so we can test the new iOS job. A drawback of this is 3.15 is still in alpha, and so won't select the docs test until RC.

Instead, when we're testing, let's select _all_ jobs, so we test docs, iOS and Android. A bit like a reverse Volkswagen mode :)

Also added summaries to the build pages.

Demos:

<table>
<tr>
 <td><a href="https://github.com/hugovk/release-tools/actions/runs/24394128567">push</a>
 <td><a href="https://github.com/hugovk/release-tools/actions/runs/24394128567">workflow_dispatch</a>
<tr>
 <td>Select all
 <td>Select based on version
<tr>
 <td><img width="556" height="472" alt="image" src="https://github.com/user-attachments/assets/fe5d94fb-15ac-4849-a306-8279ef8afef4" />
 <td><img width="551" height="471" alt="image" src="https://github.com/user-attachments/assets/1e9267db-12fb-4245-ac80-dbe59e6bfefa" />

</table>
 






