### PR TITLE
Add guard for production signing certificate on 'SourceCommit' and 'GitRemote_Other'

### DIFF
--- a/windows-release/azure-pipelines.yml
+++ b/windows-release/azure-pipelines.yml
@@ -135,8 +135,10 @@ resources:
 variables:
   ${{ if ne(parameters.GitRemote, '(Other)') }}:
     GitRemote: ${{ parameters.GitRemote }}
+    GitRemoteIsOther: false
   ${{ else }}:
     GitRemote: ${{ parameters.GitRemote_Other }}
+    GitRemoteIsOther: true
   SourceTag: ${{ parameters.SourceTag }}
   ${{ if ne(parameters.SourceCommit, 'empty') }}:
     SourceCommit: ${{ parameters.SourceCommit }}

--- a/windows-release/stage-sign.yml
+++ b/windows-release/stage-sign.yml
@@ -35,6 +35,11 @@ jobs:
       - group: CPythonTestSign
 
     steps:
+    - powershell: |
+        throw "Production signing certificate requires SourceCommit and non-other GitRemote ('$(SourceCommit)' '$(GitRemote)')"
+      displayName: "Check 'SourceCommit' and 'GitRemoteIsOther' when using production signing certificate"
+      condition: and(succeeded(), or(not(IsRealSigned), and(variables['SourceCommit'], not(variables['GitRemoteIsOther']))))
+
     - template: ./checkout.yml
 
     - powershell: |


### PR DESCRIPTION
This forces using an enumerated `GitRemote` value and `SourceCommit` (to trigger the commit SHA check) when using the production signing certificate. 