### PR TITLE
Fix repo check: b1 is special and still made from main, not 3.x

### DIFF
--- a/release.py
+++ b/release.py
@@ -193,7 +193,10 @@ class Tag:
 
     @property
     def branch(self) -> str:
-        return "main" if self.is_alpha_release else f"{self.major}.{self.minor}"
+        if self.is_alpha_release or self.is_feature_freeze_release:
+            return "main"
+        else:
+            return f"{self.major}.{self.minor}"
 
     @property
     def is_alpha_release(self) -> bool:

--- a/release.py
+++ b/release.py
@@ -195,8 +195,7 @@ class Tag:
     def branch(self) -> str:
         if self.is_alpha_release or self.is_feature_freeze_release:
             return "main"
-        else:
-            return f"{self.major}.{self.minor}"
+        return f"{self.major}.{self.minor}"
 
     @property
     def is_alpha_release(self) -> bool:

--- a/run_release.py
+++ b/run_release.py
@@ -1245,7 +1245,7 @@ def branch_new_versions(db: ReleaseShelf) -> None:
     subprocess.check_call(["git", "checkout", "main"], cwd=db["git_repo"])
 
     subprocess.check_call(
-        ["git", "checkout", "-b", release_tag.branch],
+        ["git", "checkout", "-b", release_tag.basic_version],
         cwd=db["git_repo"],
     )
 

--- a/run_release.py
+++ b/run_release.py
@@ -1168,8 +1168,13 @@ def post_release_tagging(db: ReleaseShelf) -> None:
         cwd=db["git_repo"],
     )
 
+    if release_tag.is_feature_freeze_release:
+        checkout_branch = release_tag.basic_version
+    else:
+        checkout_branch = release_tag.branch
+
     subprocess.check_call(
-        ["git", "checkout", release_tag.branch],
+        ["git", "checkout", checkout_branch],
         cwd=db["git_repo"],
     )
 

--- a/tests/test_release_tag.py
+++ b/tests/test_release_tag.py
@@ -41,26 +41,31 @@ def test_tag_phase() -> None:
     assert alpha.is_feature_freeze_release is False
     assert alpha.is_release_candidate is False
     assert alpha.is_final is False
+    assert alpha.branch == "main"
 
     assert beta1.is_alpha_release is False
     assert beta1.is_feature_freeze_release is True
     assert beta1.is_release_candidate is False
     assert beta1.is_final is False
+    assert beta1.branch == "main"
 
     assert beta4.is_alpha_release is False
     assert beta4.is_feature_freeze_release is False
     assert beta4.is_release_candidate is False
     assert beta4.is_final is False
+    assert beta4.branch == "3.13"
 
     assert rc.is_alpha_release is False
     assert rc.is_feature_freeze_release is False
     assert rc.is_release_candidate is True
     assert rc.is_final is False
+    assert rc.branch == "3.13"
 
     assert final.is_alpha_release is False
     assert final.is_feature_freeze_release is False
     assert final.is_release_candidate is False
     assert final.is_final is True
+    assert final.branch == "3.13"
 
 
 def test_tag_committed_at_not_found() -> None:

--- a/tests/test_run_release.py
+++ b/tests/test_run_release.py
@@ -59,7 +59,9 @@ def test_invalid_extract_github_owner() -> None:
     [
         # Success cases
         ("3.15.0rc1", "3.15\n", does_not_raise()),
-        ("3.15.0b1", "3.15\n", does_not_raise()),
+        ("3.15.0b3", "3.15\n", does_not_raise()),
+        ("3.15.0b2", "3.15\n", does_not_raise()),
+        ("3.15.0b1", "main\n", does_not_raise()),
         ("3.15.0a6", "main\n", does_not_raise()),
         ("3.14.3", "3.14\n", does_not_raise()),
         ("3.13.12", "3.13\n", does_not_raise()),
@@ -71,8 +73,8 @@ def test_invalid_extract_github_owner() -> None:
         ),
         (
             "3.15.0b1",
-            "main\n",
-            pytest.raises(ReleaseException, match="on main branch, expected 3.15"),
+            "3.15\n",
+            pytest.raises(ReleaseException, match="on 3.15 branch, expected main"),
         ),
         (
             "3.15.0a6",


### PR DESCRIPTION
Fix the check added in https://github.com/python/release-tools/pull/334:

```pytb
❯ .venv/bin/python run_release.py --repository ../cpython-3.15 --ssh-user hugovk --release 3.15.0b1
Release data:
- Branch: 3.15
- Release tag: 3.15.0b1
- Normalized release tag: 3.15.0
- Git repo: ../cpython-3.15
- SSH username: hugovk
- SSH key: Default
- Sign with GPG: False
- Security release: False

✅  Checking gh is available
✅  Checking Git is available
✅  Checking make is available
✅  Checking blurb is available
✅  Checking Docker is available
✅  Checking Docker is running
✅  Checking autoconf is available
✅  Validating ssh connection to downloads.nyc1.psf.io and docs.nyc1.psf.io
✅  Checking Sigstore CLI
💥  Checking CPython repository branch
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1483, in <module>
    main()
    ~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 1479, in main
    automata.run()
    ~~~~~~~~~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 281, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 278, in run
    self.current_task(self.db)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/hugo/github/release-tools/release.py", line 151, in __call__
    return getattr(self, "function")(db)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 433, in check_cpython_repo_branch
    raise ReleaseException(
    ...<2 lines>...
    )
ReleaseException: CPython repository is on main branch, expected 3.15
```

Beta 1 is special: like all alphas, we start from the `main` branch. At the end of b1, the next `3.x` branch is created, and then that will be used for b2 and later.
