### PR TITLE
Cache duplicate `query_object` calls

### DIFF
--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -30,6 +30,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Generator
+from functools import cache
 from os import path
 from typing import Any, NoReturn
 
@@ -293,6 +294,7 @@ def list_files(
             continue
 
 
+@cache
 def query_object(base_url: str, objtype: str, **params: Any) -> int:
     """Find an API object by query parameters."""
     uri = base_url + f"downloads/{objtype}/"


### PR DESCRIPTION
Small performance improvement.

`query_object` is called once per release file:

```python
    for rfile, file_desc, os_slug, add_download, add_desc in release_files:
        if not os_slug:
            continue
        os_pk = query_object(args.base_url, "os", slug=os_slug)
```

There might be 12 release files but four slugs:

|  | File | Slug |
|---|:--|:--|
| 1 | `Python-3.14.5.tgz` | source |
| 2 | `Python-3.14.5.tar.xz` | source |
| 3 | `windows-3.14.5.json` | windows |
| 4 | `python-3.14.5-embed-amd64.zip` | windows |
| 5 | `python-3.14.5-embed-arm64.zip` | windows |
| 6 | `python-3.14.5-embed-win32.zip` | windows |
| 7 | `python-3.14.5-amd64.exe` | windows |
| 8 | `python-3.14.5-arm64.exe` | windows |
| 9 | `python-3.14.5.exe` | windows |
| 10 | `python-3.14.5-macos11.pkg` | macos |
| 11 | `python-3.14.5-aarch64-linux-android.tar.gz` | android |
| 12 | `python-3.14.5-x86_64-linux-android.tar.gz` | android |

So we only need to call the API four times, not 12.
