### PR TITLE
Only set group and permissions on downloads dir if needed

### DIFF
--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -366,9 +366,9 @@ def sign_release_files_with_sigstore(
                 ]
             )
 
-            run_cmd(["chmod", "644", sig_file])
-            run_cmd(["chmod", "644", cert_file])
-            run_cmd(["chmod", "644", bundle_file])
+            os.chmod(sig_file, 0o644)
+            os.chmod(cert_file, 0o644)
+            os.chmod(bundle_file, 0o644)
     else:
         print("All release files already signed with Sigstore")
 

--- a/run_release.py
+++ b/run_release.py
@@ -809,24 +809,22 @@ def place_files_in_download_folder(db: ReleaseShelf) -> None:
         if channel.recv_exit_status() != 0:
             raise ReleaseException(channel.recv_stderr(1000))
 
-    execute_command(f"mkdir -p {destination}")
-    execute_command(f"cp {source}/downloads/* {destination}")
-    execute_command(f"chgrp downloads {destination}")
-    execute_command(f"chmod 775 {destination}")
-    execute_command(f"find {destination} -type f -exec chmod 664 {{}} \\;")
-
-    # Docs
-
-    release_tag = db["release"]
-    if release_tag.is_final or release_tag.is_release_candidate:
-        source = f"/home/psf-users/{db['ssh_user']}/{db['release']}"
-        destination = f"/srv/www.python.org/ftp/python/doc/{release_tag}"
-
+    def copy_and_set_permissions(source_glob: str, destination: str) -> None:
         execute_command(f"mkdir -p {destination}")
-        execute_command(f"cp {source}/docs/* {destination}")
+        execute_command(f"cp {source_glob} {destination}")
         execute_command(f"chgrp downloads {destination}")
         execute_command(f"chmod 775 {destination}")
         execute_command(f"find {destination} -type f -exec chmod 664 {{}} \\;")
+
+    copy_and_set_permissions(f"{source}/downloads/*", destination)
+
+    # Docs
+    release_tag = db["release"]
+    if release_tag.is_final or release_tag.is_release_candidate:
+        copy_and_set_permissions(
+            f"{source}/docs/*",
+            f"/srv/www.python.org/ftp/python/doc/{release_tag}",
+        )
 
 
 def upload_docs_to_the_docs_server(db: ReleaseShelf) -> None:

--- a/run_release.py
+++ b/run_release.py
@@ -812,9 +812,18 @@ def place_files_in_download_folder(db: ReleaseShelf) -> None:
     def copy_and_set_permissions(source_glob: str, destination: str) -> None:
         execute_command(f"mkdir -p {destination}")
         execute_command(f"cp {source_glob} {destination}")
-        execute_command(f"chgrp downloads {destination}")
-        execute_command(f"chmod 775 {destination}")
-        execute_command(f"find {destination} -type f -exec chmod 664 {{}} \\;")
+        # Skip chgrp/chmod if already correct: another RM may have created
+        # the directory, and only the owner can change group or permissions.
+        execute_command(
+            f"find {destination} -maxdepth 0 ! -group downloads "
+            f"-exec chgrp downloads {{}} +"
+        )
+        execute_command(
+            f"find {destination} -maxdepth 0 ! -perm 775 -exec chmod 775 {{}} +"
+        )
+        execute_command(
+            f"find {destination} -type f ! -perm 664 -exec chmod 664 {{}} +"
+        )
 
     copy_and_set_permissions(f"{source}/downloads/*", destination)
 


### PR DESCRIPTION

`run_release.py`:

During the 3.14.4 release, I held off uploading the files built by this repo (tarballs, docs, Android etc), awaiting some Windows build issues. This took some time. Once that was sorted, I continued.

But by this time, the macOS files had already been uploaded:

```console
$ ls -l /srv/www.python.org/ftp/python/

drwxrwxr-x  47 hugovk    downloads  65536 Oct  7 14:16 3.14.0
drwxrwxr-x   5 hugovk    downloads   4096 Dec  2 16:18 3.14.1
drwxrwxr-x   5 hugovk    downloads   4096 Dec  5 20:01 3.14.2
drwxrwxr-x   5 hugovk    downloads   4096 Feb  3 18:29 3.14.3
drwxrwxr-x   2 nad       downloads   4096 Apr  7 15:15 3.14.4
drwxrwxr-x  26 hugovk    downloads  36864 Apr  7 14:12 3.15.0
```

Usually, the tarballs etc. get there first, but the script fell over because Ned had already created the directories and set permissions, and my user could not do that:

```pytb
✅  Upload files to the PSF downloads server
💥  Place files in the download folder
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1483, in <module>
    main()
    ~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 1479, in main
    automata.run()
    ~~~~~~~~~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 281, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 278, in run
    self.current_task(self.db)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/hugo/github/release-tools/release.py", line 151, in __call__
    return getattr(self, "function")(db)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 836, in place_files_in_download_folder
    execute_command(f"chgrp downloads {destination}")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 832, in execute_command
    raise ReleaseException(channel.recv_stderr(1000))
ReleaseException: b"chgrp: changing group of '/srv/www.python.org/ftp/python/3.14.4': Operation not permitted\n"
```

After commenting out the `chgrp`, the `chmod` also fell over:


```pytb
💥  Place files in the download folder
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1483, in <module>
    main()
    ~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 1479, in main
    automata.run()
    ~~~~~~~~~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 281, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 278, in run
    self.current_task(self.db)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/hugo/github/release-tools/release.py", line 151, in __call__
    return getattr(self, "function")(db)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 837, in place_files_in_download_folder
    execute_command(f"chmod 775 {destination}")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 832, in execute_command
    raise ReleaseException(channel.recv_stderr(1000))
ReleaseException: b"chmod: changing permissions of '/srv/www.python.org/ftp/python/3.14.4': Operation not permitted\n"
```

So for the release I commented the `chmod` as well.

The proper fix is to check the group and permissions first, and only try setting them when needed.

Also refactored these similar calls for downloads + docs into `copy_and_set_permissions()`.


---

`add_to_pydotorg.py` - replace calls like `run_cmd(["chmod", "644", sig_file])` with direct `os.chmod(sig_file, 0o644)` calls.
