### PR TITLE
Remove unused `minor_version_tuple()` and ` ls_ssh()`

### DIFF
--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -208,12 +208,6 @@ def minor_version(release: str) -> str:
     return ".".join(m.groups()[:2])
 
 
-def minor_version_tuple(release: str) -> tuple[int, int]:
-    m = tag_cre.match(release)
-    assert m is not None, f"Invalid release: {release}"
-    return int(m.groups()[0]), int(m.groups()[1])
-
-
 def build_file_dict(
     ftp_root: str,
     release: str,

--- a/tests/test_add_to_pydotorg.py
+++ b/tests/test_add_to_pydotorg.py
@@ -119,19 +119,6 @@ def test_minor_version(release: str, expected: str) -> None:
 @pytest.mark.parametrize(
     ["release", "expected"],
     [
-        ("3.9.0a0", (3, 9)),
-        ("3.10.0b3", (3, 10)),
-        ("3.11.0rc2", (3, 11)),
-        ("3.12.15", (3, 12)),
-    ],
-)
-def test_minor_version_tuple(release: str, expected: tuple[int, int]) -> None:
-    assert add_to_pydotorg.minor_version_tuple(release) == expected
-
-
-@pytest.mark.parametrize(
-    ["release", "expected"],
-    [
         ((3, 13, 0), "for macOS 10.13 and later"),
         ((3, 14, 0), "for macOS 10.15 and later"),
     ],

--- a/windows-release/merge-and-upload.py
+++ b/windows-release/merge-and-upload.py
@@ -113,18 +113,6 @@ def download_ssh(source, dest):
     _run(*_std_args(PSCP), f"{UPLOAD_USER}@{UPLOAD_HOST}:{source}", dest)
 
 
-def ls_ssh(dest):
-    if not UPLOAD_HOST or LOCAL_INDEX:
-        print("Skipping ls of", dest, "because UPLOAD_HOST is missing")
-        return
-    try:
-        _run(*_std_args(PSCP), "-ls", f"{UPLOAD_USER}@{UPLOAD_HOST}:{dest}")
-    except RunError as ex:
-        if not ex.args[1].rstrip().endswith("No such file or directory"):
-            raise
-        print(dest, "was not found")
-
-
 def url2path(url):
     if not UPLOAD_URL_PREFIX:
         raise ValueError("%UPLOAD_URL_PREFIX% was not set")


### PR DESCRIPTION
* Last use of `minor_version_tuple()` was dropped in https://github.com/python/release-tools/commit/1f15dab61285e4eee98c280f8d0caa00d55fbe65 / [#269](https://github.com/python/release-tools/pull/269)

* `ls_ssh()` was added in https://github.com/python/release-tools/commit/b63dc242afa1a66fdefa9bdca024a8c585d63663 / [#236](https://github.com/python/release-tools/pull/236) but never used