### PR TITLE
Only set permissions for current user's files in main dir

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -822,7 +822,8 @@ def place_files_in_download_folder(db: ReleaseShelf) -> None:
             f"find {destination} -maxdepth 0 ! -perm 775 -exec chmod 775 {{}} +"
         )
         execute_command(
-            f"find {destination} -type f ! -perm 664 -exec chmod 664 {{}} +"
+            f"find {destination} -maxdepth 1 -type f -user $USER ! -perm 664 "
+            f"-exec chmod 664 {{}} +"
         )
 
     copy_and_set_permissions(f"{source}/downloads/*", destination)


### PR DESCRIPTION
Follow on from https://github.com/python/release-tools/pull/391.

This happened during yesterday's 3.15.0b2 release:

```pytb
✅  Upload files to the PSF downloads server
💥  Place files in the download folder
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1504, in <module>
    main()
    ~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 1500, in main
    automata.run()
    ~~~~~~~~~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 255, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 252, in run
    self.current_task(self.db)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/hugo/github/release-tools/release.py", line 151, in __call__
    return getattr(self, "function")(db)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 828, in place_files_in_download_folder
    copy_and_set_permissions(f"{source}/downloads/*", destination)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 824, in copy_and_set_permissions
    execute_command(
    ~~~~~~~~~~~~~~~^
        f"find {destination} -type f ! -perm 664 -exec chmod 664 {{}} +"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/hugo/github/release-tools/run_release.py", line 810, in execute_command
    raise ReleaseException(channel.recv_stderr(1000))
ReleaseException: b'find: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/test_pdb.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/tcltk.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/exe_d.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/lib.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/dev.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/ucrt.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/doc.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/tcltk_d.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/freethreaded_pdb.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/exe_pdb.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ftp/python/3.15.0/amd64a1/core_d.msi\xe2\x80\x99: Permission denied\nfind: \xe2\x80\x98/srv/www.python.org/ft'
```

What happened:

There were already Windows files and subdirs (for example `3.15.0/amd64a1/`) owned by sdower in the directory, and it failed when trying to set new permissions on them.

The fix is only to attempt setting them in the top level `3.15.0/` (`-maxdepth 1`) and only for the files owned by the current user (`-user $USER`), which is the RM who just uploaded the source/Android/etc files.

Yesterday, I made this change locally, and continued the release, and it worked fine.