### PR TITLE
Prompt to include Windows build in email to platform RMs

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -998,6 +998,9 @@ def send_email_to_platform_release_managers(db: ReleaseShelf) -> None:
     print(
         "build-release workflow: https://github.com/python/release-tools/actions/runs/[ENTER-RUN-ID-HERE]"
     )
+    print(
+        "Windows build: https://dev.azure.com/Python/cpython/_build/results?buildId=[ENTER-BUILD-ID-HERE]&view=results"
+    )
     print()
 
     if not ask_question(


### PR DESCRIPTION
Now we can also kick off the Windows build and don't need to wait for someone else, it's useful to include this in the email, for example:

```
https://github.com/hugovk/cpython/tree/v3.15.0b2
Git commit SHA: 94a64bbc6ce89644cf02b82c723d9cc37f6a1870
build-release workflow: https://github.com/python/release-tools/actions/runs/26830150475
Windows build: https://dev.azure.com/Python/cpython/_build/results?buildId=170834&view=results
```
