### PR TITLE
Fix add_to_pydotorg session cleanup calls

### DIFF
--- a/add_to_pydotorg.py
+++ b/add_to_pydotorg.py
@@ -328,7 +328,7 @@ def post_object(base_url: str, objtype: str, datadict: dict[str, Any]) -> int:
 
 def delete_object(base_url: str, objtype: str, pk: int) -> None:
     """Delete an existing API object."""
-    resp = requests.delete(base_url + f"downloads/{objtype}/{pk}/", headers=headers)
+    resp = session.delete(f"{base_url}downloads/{objtype}/{pk}/")
     if resp.status_code != 204:
         raise RuntimeError(f"Deleting {objtype} {pk} failed: {resp.status_code}")
 

--- a/tests/test_add_to_pydotorg.py
+++ b/tests/test_add_to_pydotorg.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import requests
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 os.environ["AUTH_INFO"] = "test_username:test_api_key"
@@ -87,12 +86,31 @@ def test_post_object_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_post(*args: Any, **kwargs: Any) -> Response:
         return Response()
 
-    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(add_to_pydotorg.session, "post", fake_post)
 
     with pytest.raises(RuntimeError, match="validation failed"):
         add_to_pydotorg.post_object(
             "https://example.invalid/api/v1/", "release_file", {"slug": "bad"}
         )
+
+
+def test_delete_object_uses_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Response:
+        status_code = 204
+
+    calls: list[str] = []
+
+    def fake_delete(url: str) -> Response:
+        calls.append(url)
+        return Response()
+
+    monkeypatch.setattr(add_to_pydotorg.session, "delete", fake_delete)
+
+    add_to_pydotorg.delete_object(
+        "https://example.invalid/api/v1/", "release_file", 123
+    )
+
+    assert calls == ["https://example.invalid/api/v1/downloads/release_file/123/"]
 
 
 def test_create_release_files_cleans_up_created_rows(


### PR DESCRIPTION
## Summary

Follow-up to #403, fixing its interaction with the shared requests session introduced in #390.

`delete_object()` now uses the module-level `session`, matching the other API helpers, and the `post_object()` failure test now patches `add_to_pydotorg.session.post` instead of `requests.post`.

## Tests

- `tox -q -e py313 -- tests/test_add_to_pydotorg.py::test_post_object_raises_on_failure tests/test_add_to_pydotorg.py::test_delete_object_uses_session tests/test_add_to_pydotorg.py::test_create_release_files_cleans_up_created_rows`
- `tox -q -e lint`
- `tox -q -e mypy`