### PR TITLE
Add "New deprecations" subheading to What's New template

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -136,10 +136,18 @@ module_name
 Deprecated
 ==========
 
+New deprecations
+----------------
+
 * module_name:
   TODO
 
 .. Add deprecations above alphabetically, not here at the end.
+
+
+.. TODO .. include:: ../deprecations/pending-removal-in-3.xx.rst
+
+.. include:: ../deprecations/pending-removal-in-future.rst
 
 
 Porting to Python {version}


### PR DESCRIPTION
This is in 3.14: https://docs.python.org/3/whatsnew/3.14.html#new-deprecations
And 3.15: https://docs.python.org/3.15/whatsnew/3.15.html#new-deprecations
And being manually added to 3.16: https://github.com/python/cpython/pull/151915

Let's put it in the template for 3.17 and beyond.