### PR TITLE
Automatically suffix the README version after a release

### DIFF
--- a/release.py
+++ b/release.py
@@ -519,6 +519,13 @@ def tweak_readme(tag: Tag, filename: str = "README.rst", done: bool = False) -> 
     lines[1] = underline
     content = "\n".join(lines)
 
+    if done:
+        # Post-release only changes the version line; the substitutions below
+        # already ran at bump time, and skipping them avoids the PEP fetch.
+        readme.write_text(content)
+        print("done")
+        return
+
     DOCS_URL = r"https://docs\.python\.org/"
     X_Y = r"\d+\.\d+"
 

--- a/release.py
+++ b/release.py
@@ -450,6 +450,16 @@ def constant_replace(
     os.rename(filename + ".new", filename)
 
 
+def get_version_suffix(tag: Tag, done: bool = False) -> str:
+    # 3.15+ uses "+dev" for PEP 440 local-version compliance;
+    # 3.14 and earlier keep the bare "+" suffix.
+    if done:
+        suffix = "+dev" if tag.as_tuple() >= (3, 15) else "+"
+    else:
+        suffix = ""
+    return suffix
+
+
 def tweak_patchlevel(
     tag: Tag, filename: str = "Include/patchlevel.h", done: bool = False
 ) -> None:
@@ -470,12 +480,7 @@ def tweak_patchlevel(
         "rc": "PY_RELEASE_LEVEL_GAMMA",
         "f": "PY_RELEASE_LEVEL_FINAL",
     }[tag.level]
-    if done:
-        # 3.15+ uses "+dev" for PEP 440 local-version compliance;
-        # 3.14 and earlier keep the bare "+" suffix.
-        plus = "+dev" if tag.as_tuple() >= (3, 15) else "+"
-    else:
-        plus = ""
+    plus = get_version_suffix(tag, done=done)
     new_constants = template.format(tag=tag, level_def=level_def, plus=plus)
     if tag.as_tuple() >= (3, 7, 0, "a", 3):
         new_constants = new_constants.expandtabs()
@@ -499,14 +504,16 @@ def get_pep_number(version: str) -> str:
     return "TODO"
 
 
-def tweak_readme(tag: Tag, filename: str = "README.rst") -> None:
+def tweak_readme(tag: Tag, filename: str = "README.rst", done: bool = False) -> None:
     print(f"Updating {filename}...", end=" ")
     readme = Path(filename)
 
     # Update first line: "This is Python version X.Y.Z {release_level} N"
     # and update length of underline in second line to match.
     lines = readme.read_text().split("\n")
-    this_is = f"This is Python version {tag.long_name}"
+    this_is = (
+        f"This is Python version {tag.long_name}{get_version_suffix(tag, done=done)}"
+    )
     underline = "=" * len(this_is)
     lines[0] = this_is
     lines[1] = underline
@@ -858,6 +865,7 @@ def make_tag(tag: Tag, *, sign_gpg: bool = True) -> bool:
 
 
 def done(tag: Tag) -> None:
+    tweak_readme(tag, done=True)
     tweak_patchlevel(tag, done=True)
 
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -204,3 +204,34 @@ def test_tweak_readme(
     assert expected_pep_line in new_contents
     assert original_contents.endswith("\n")
     assert new_contents.endswith("\n")
+
+
+@pytest.mark.parametrize(
+    ["test_tag", "expected_version"],
+    [
+        # 3.14 and earlier keep the bare "+" suffix.
+        ("3.14.2", "This is Python version 3.14.2+"),
+        ("3.14.0b2", "This is Python version 3.14.0 beta 2+"),
+        # 3.15+ uses "+dev" for PEP 440 local-version compliance.
+        ("3.15.1", "This is Python version 3.15.1+dev"),
+        ("3.15.0b1", "This is Python version 3.15.0 beta 1+dev"),
+        ("3.16.0a1", "This is Python version 3.16.0 alpha 1+dev"),
+    ],
+)
+def test_tweak_readme_done(
+    tmp_path: Path, test_tag: str, expected_version: str
+) -> None:
+    # Arrange
+    tag = release.Tag(test_tag)
+
+    original_readme_file = Path(__file__).parent / "README.rst"
+    readme_file = tmp_path / "README.rst"
+    readme_file.write_text(original_readme_file.read_text())
+
+    # Act
+    release.tweak_readme(tag, filename=str(readme_file), done=True)
+
+    # Assert
+    new_lines = readme_file.read_text().split("\n")
+    assert new_lines[0] == expected_version
+    assert new_lines[1] == "=" * len(expected_version)


### PR DESCRIPTION
Closes #169 

Opted to automatically update the README (rather than remind), using option 1 from the discussion: This is Python version 3.15.0 beta 3+dev style suffixes. This happens in release.py --done, alongside the existing patchlevel.h update, so it lands in the post-release commit: + for 3.14 and earlier, +dev for 3.15+.