### PR TITLE
Support `soft-deprecated` directive

### DIFF
--- a/tests/test_update_version_next.py
+++ b/tests/test_update_version_next.py
@@ -18,6 +18,8 @@ Here, all occurrences of NEXT (lowercase) should be changed:
 
 .. deprecated-removed:: next 4.0
 
+.. soft-deprecated:: next
+
 whitespace:
 
 ..   versionchanged:: next

--- a/update_version_next.py
+++ b/update_version_next.py
@@ -21,7 +21,7 @@ DIRECTIVE_RE = re.compile(
     r"""
         (?P<before>
             \s*\.\.\s+
-            (version(added|changed|removed)|deprecated(-removed)?)
+            (version(added|changed|removed)|deprecated(-removed)?|soft-deprecated)
             \s*::\s*
         )
         next


### PR DESCRIPTION
This was added in https://github.com/python/cpython/pull/148630 and needs support here too.

Showed up during today's 3.15.0rc1 release:

```html
Checking built docs for '(unreleased)'
/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpgz1mpshy/python-3.15.0rc1-docs-html/c-api/type.html:1051:<p><span class="versionmodified soft-deprecated"><a class="reference internal" href="../glossary.html#term-soft-deprecated">Soft deprecated</a> since version 3.15.0rc1 (unreleased): </span>Prefer <a class="reference internal" href="#c.PyType_FromSlots" title="PyType_FromSlots"><code class="xref c c-func docutils literal notranslate"><span class="pre">PyType_FromSlots()</span></code></a> in new code.</p>
/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpgz1mpshy/python-3.15.0rc1-docs-html/c-api/type.html:1079:<p><span class="versionmodified soft-deprecated"><a class="reference internal" href="../glossary.html#term-soft-deprecated">Soft deprecated</a> since version 3.15.0rc1 (unreleased): </span>Prefer <a class="reference internal" href="#c.PyType_FromSlots" title="PyType_FromSlots"><code class="xref c c-func docutils literal notranslate"><span class="pre">PyType_FromSlots()</span></code></a> in new code.</p>
/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpgz1mpshy/python-3.15.0rc1-docs-html/c-api/type.html:1103:<p><span class="versionmodified soft-deprecated"><a class="reference internal" href="../glossary.html#term-soft-deprecated">Soft deprecated</a> since version 3.15.0rc1 (unreleased): </span>Prefer <a class="reference internal" href="#c.PyType_FromSlots" title="PyType_FromSlots"><code class="xref c c-func docutils literal notranslate"><span class="pre">PyType_FromSlots()</span></code></a> in new code.</p>
/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpgz1mpshy/python-3.15.0rc1-docs-html/c-api/type.html:1125:<p><span class="versionmodified soft-deprecated"><a class="reference internal" href="../glossary.html#term-soft-deprecated">Soft deprecated</a> since version 3.15.0rc1 (unreleased): </span>Prefer <a class="reference internal" href="#c.PyType_FromSlots" title="PyType_FromSlots"><code class="xref c c-func docutils literal notranslate"><span class="pre">PyType_FromSlots()</span></code></a> in new code.</p>
/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpgz1mpshy/python-3.15.0rc1-docs-html/c-api/module.html:1054:<p><span class="versionmodified soft-deprecated"><a class="reference internal" href="../glossary.html#term-soft-deprecated">Soft deprecated</a> since version 3.15.0rc1 (unreleased): </span>Prefer <a class="reference internal" href="#c.PyModule_FromSlotsAndSpec" title="PyModule_FromSlotsAndSpec"><code class="xref c c-func docutils literal notranslate"><span class="pre">PyModule_FromSlotsAndSpec()</span></code></a> in new code.</p>
/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpgz1mpshy/python-3.15.0rc1-docs-html/c-api/module.html:1078:<p><span class="versionmodified soft-deprecated"><a class="reference internal" href="../glossary.html#term-soft-deprecated">Soft deprecated</a> since version 3.15.0rc1 (unreleased): </span>Prefer <a class="reference internal" href="#c.PyModule_FromSlotsAndSpec" title="PyModule_FromSlotsAndSpec"><code class="xref c c-func docutils literal notranslate"><span class="pre">PyModule_FromSlotsAndSpec()</span></code></a> in new code.</p>
/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpgz1mpshy/python-3.15.0rc1-docs-html/c-api/module.html:1090:<p><span class="versionmodified soft-deprecated"><a class="reference internal" href="../glossary.html#term-soft-deprecated">Soft deprecated</a> since version 3.15.0rc1 (unreleased): </span>To run a module’s own execution slots, prefer <a class="reference internal" href="#c.PyModule_Exec" title="PyModule_Exec"><code class="xref c c-func docutils literal notranslate"><span class="pre">PyModule_Exec()</span></code></a>,
Are these `(unreleased)` strings in built docs OK?
Enter yes or no:
```

Not too much of a problem for this pre-release, but let's fix for (probably tomorrow's) 3.14 and 3.13.