### PR TITLE
Don't fail when sigstore logs to stderr

### DIFF
--- a/run_release.py
+++ b/run_release.py
@@ -1090,12 +1090,18 @@ def run_add_to_python_dot_org(db: ReleaseShelf) -> None:
     stdin, stdout, stderr = client.exec_command(
         f"AUTH_INFO={auth_info} SIGSTORE_IDENTITY_TOKEN={identity_token} python3 add_to_pydotorg.py {db['release']}"
     )
-    stderr_text = stderr.read().decode()
-    if stderr_text:
-        raise paramiko.SSHException(f"Failed to execute the command: {stderr_text}")
     stdout_text = stdout.read().decode()
+    stderr_text = stderr.read().decode()
+    exit_status = stdout.channel.recv_exit_status()
+    if exit_status != 0:
+        raise paramiko.SSHException(
+            f"Failed to execute the command (exit code {exit_status}): {stderr_text}"
+        )
     print("-- Command output --")
     print(stdout_text)
+    if stderr_text:
+        print("-- Command stderr --")
+        print(stderr_text)
     print("-- End of command output --")
 
 


### PR DESCRIPTION
Sigstore v3 used to `print` the "Transparency log entry created at index:" lines, but v4 logs them to stderr instead:

* https://github.com/sigstore/sigstore-python/blob/v3.6.7/sigstore/_cli.py#L706-L708
* https://github.com/sigstore/sigstore-python/blob/v4.0.0/sigstore/_cli.py#L683-L685
* https://github.com/sigstore/sigstore-python/pull/1468

When we run sigstore, we treat anything on stderr as an error, and it now falls over.

```pytb
💥  Add files to python.org download page
Traceback (most recent call last):
  File "/Users/hugo/github/release-tools/run_release.py", line 1508, in <module>
    main()
    ~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 1504, in main
    automata.run()
    ~~~~~~~~~~~~^^
  File "/Users/hugo/github/release-tools/run_release.py", line 265, in run
    raise e from None
  File "/Users/hugo/github/release-tools/run_release.py", line 262, in run
    self.current_task(self.db)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/hugo/github/release-tools/release.py", line 153, in __call__
    return getattr(self, "function")(db)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/Users/hugo/github/release-tools/run_release.py", line 1104, in run_add_to_python_dot_org
    raise paramiko.SSHException(f"Failed to execute the command: {stderr_text}")
paramiko.ssh_exception.SSHException: Failed to execute the command: [14:11:19] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619340
[14:11:21] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619402
[14:11:22] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619453
[14:11:24] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619530
[14:11:26] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619584
[14:11:28] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619639
[14:11:29] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619685
[14:11:31] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619733
[14:11:33] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619793
[14:11:35] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619861
[14:11:37] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619926
[14:11:38] INFO     Transparency log entry created at index:         _cli.py:729
                    2340619988
[14:11:40] INFO     Transparency log entry created at index:         _cli.py:729
                    2340620035
```

Instead, let's print the stderr, and only fail on non-zero output.

